### PR TITLE
Feature | D | Removing Sign Up Option for Admin

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -24,8 +24,7 @@
 class AdminUser < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :recoverable, :rememberable, :validatable
 
   has_many :organizations, as: :creator
 end


### PR DESCRIPTION
Title: [Epic D - Organization Page Management] Remove Sign Up Route for AdminUsers

# Context
[Trello Card](https://trello.com/c/Y3tAYrbj/74-remove-sign-up-route-for-admin-users)

# Changes
- [x] Remove registerable module from AdminUsers