### PR TITLE
Adding OfficeHours Validation to Location + Fixing Views

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -22,6 +22,7 @@
 class Location < ActiveRecord::Base
   include Locations::Searchable
   include Locations::Officeable
+  validates_with LocationValidator
 
   belongs_to :organization, optional: true
   
@@ -31,7 +32,7 @@ class Location < ActiveRecord::Base
   has_many :location_services, dependent: :destroy
   has_many :services, through: :location_services
   
-  has_one :phone_number
+  has_one :phone_number, dependent: :destroy
   has_one :social_media, through: :organization
 
   validates :name, presence: true

--- a/app/views/locations/show.html.slim
+++ b/app/views/locations/show.html.slim
@@ -39,7 +39,10 @@ div class=""
           p class="text-sm leading-6 font-base text-gray-2"
             span class="font-bold"
               ' Hours:
-            - if @location.open_now?
+            - if @location.appointment_only?
+              span class="text-green-fountain"
+                | Appointment only
+            - elsif @location.open_now?
               span class="text-green-fountain"
                 | Open
             - else

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -85,13 +85,16 @@
                 p class="text-xs text-gray-4"
                   | +1 888 478 0036
                 p class="text-xs font-medium text-gray-2"
-                  - unless result.open_now?
+                  - if result.appointment_only?
                     span class="text-states-error"
-                      ' Closed
+                      ' Appointment only
+                  - elsif result.open_now?
+                    span class="text-green-error"
+                      ' Open
                     = result.decorate.closed_office_hours_display
                   - else
-                    span class="text-green-fountain"
-                      ' Open
+                    span class="text-states-fountain"
+                      ' Closed
 
       div class="relative hidden w-full md:flex h-map-height" data-controller="places" data-places-zoom-value="10"  data-action="google-maps-callback@window->places#initMap" data-places-imageurl-value="#{asset_path 'markergc.png'}"
         div# class="absolute inset-0 w-full h-full" data-places-target="map"
@@ -107,10 +110,14 @@
               p class="text-xs text-gray-4"
                 | +1 888 478 0036
               p class="text-xs font-medium text-gray-2"
-                - unless result.open_now?
+                - if result.appointment_only?
                   span class="text-states-error"
-                    ' Closed
+                    ' Appointment only
+                - elsif result.open_now?
+                  span class="text-green-error"
+                    ' Open
                   = result.decorate.closed_office_hours_display
                 - else
-                  span class="text-green-fountain"
-                    ' Open
+                  span class="text-states-fountain"
+                    ' Closed
+              


### PR DESCRIPTION
# [Office hours validations]

# Bug
Locations were being allowed to be created without 7 OfficeHours, breaking the view. Futher, the views were only accounting for open_now?, without considering appointment_only.

# Changes
- [x] Updating OH validation on Location
- [x] Adding appointment_only option to location show and search show

