### PR TITLE
Fixing DB Constrains

### DIFF
--- a/db/migrate/20210923212719_create_organization_mission_statement_and_vision_statement_and_tagline_and_description_translations_for_mobility_column_backend.rb
+++ b/db/migrate/20210923212719_create_organization_mission_statement_and_vision_statement_and_tagline_and_description_translations_for_mobility_column_backend.rb
@@ -5,11 +5,11 @@ class CreateOrganizationMissionStatementAndVisionStatementAndTaglineAndDescripti
   def change
     add_column :organizations, :mission_statement_en, :text, null: false
     add_column :organizations, :mission_statement_es, :text
-    add_column :organizations, :vision_statement_en, :text, null: false
+    add_column :organizations, :vision_statement_en, :text
     add_column :organizations, :vision_statement_es, :text
-    add_column :organizations, :tagline_en, :text, null: false
+    add_column :organizations, :tagline_en, :text
     add_column :organizations, :tagline_es, :text
-    add_column :organizations, :description_en, :text, null: false
+    add_column :organizations, :description_en, :text
     add_column :organizations, :description_es, :text
 
     add_index :organizations, :mission_statement_en

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -193,9 +193,9 @@ ActiveRecord::Schema.define(version: 2021_11_30_222523) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "mission_statement_en", null: false
     t.text "mission_statement_es"
-    t.text "vision_statement_en", null: false
+    t.text "vision_statement_en"
     t.text "vision_statement_es"
-    t.text "tagline_en", null: false
+    t.text "tagline_en"
     t.text "tagline_es"
     t.string "second_name"
     t.string "phone_number"


### PR DESCRIPTION
# [Fixing DB Constrains]
Only mission_statement_en should be required when creating a new organization. 


# Changes
- [x] Updating the create organization migration


