### PR TITLE
Updating Validations / DB Constrans

### DIFF
--- a/db/migrate/20220104160700_change_null_constrains_from_organization.rb
+++ b/db/migrate/20220104160700_change_null_constrains_from_organization.rb
@@ -1,0 +1,6 @@
+class ChangeNullConstrainsFromOrganization < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :organizations, :vision_statement_en, true
+    change_column_null :organizations, :tagline_en, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_222523) do
+ActiveRecord::Schema.define(version: 2022_01_04_160700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -193,9 +193,9 @@ ActiveRecord::Schema.define(version: 2021_11_30_222523) do
     t.datetime "updated_at", precision: 6, null: false
     t.text "mission_statement_en", null: false
     t.text "mission_statement_es"
-    t.text "vision_statement_en", null: false
+    t.text "vision_statement_en"
     t.text "vision_statement_es"
-    t.text "tagline_en", null: false
+    t.text "tagline_en"
     t.text "tagline_es"
     t.string "second_name"
     t.string "phone_number"


### PR DESCRIPTION
# [Fixing DB Constrains]
Only mission_statement_en should be required when creating a new organization. 


# Changes
- [x] new migration with change column null requirements


