### PR TITLE
Fix | Limiting Amount of Characters in Description

### DIFF
--- a/app/components/result_card/component.html.erb
+++ b/app/components/result_card/component.html.erb
@@ -38,7 +38,7 @@
       WHAT WE DO
     </h6>
     <p class="text-sm text-black">
-      <%= @description %>
+      <%= formated_description %>
     </p>
   </div>
   <div class="flex flex-row justify-end">

--- a/app/components/result_card/component.rb
+++ b/app/components/result_card/component.rb
@@ -23,4 +23,8 @@ class ResultCard::Component < ViewComponent::Base
     end
     uri.to_s
   end
+
+  def formated_description
+    @description.length <= 280 ? @description : "#{@description[0..280]} (...)"
+  end
 end


### PR DESCRIPTION
## What was changed:
- [x] - limiting "what we do"  in search result component.