### PR TITLE
Feature | Fix space bar bug on the search bar of the filters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,6 +529,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  arm64-darwin-21
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/app/javascript/controllers/extend_dropdown_controller.js
+++ b/app/javascript/controllers/extend_dropdown_controller.js
@@ -15,18 +15,12 @@ export default class extends Dropdown {
     this.activeClass = this.data.get('activeClass') || null
     this.enteringClass = this.data.get('enteringClass') || null
     this.leavingClass = this.data.get('leavingClass') || null
-    if (this.hasButtonTarget) {
-      this.buttonTarget.addEventListener("keydown", this._onMenuButtonKeydown)
-    }
 
     this.element.setAttribute("aria-haspopup", "true")
     document.addEventListener('keydown', this.keyboardListener)
   }
 
   disconnect() {
-    if (this.hasButtonTarget) {
-      this.buttonTarget.removeEventListener("keydown", this._onMenuButtonKeydown)
-    }
 
     document?.removeEventListener('keydown', this.keyboardListener);
     this.activeIndex = 0;


### PR DESCRIPTION
## What Changed
- Refactor dropdown stimulus controller (Filters) by removing keydown listener.

## Why this change was made
- The user should be able to search by words and spaces on filters menu.

## How to test

1.  Run rails server.
2. Open browser.
3. Open the dropdown for searching.
4. Search by words and spaces on filters menu. For example `children & family`, the app should shows the options. 

