### PR TITLE
Feature | Terms of use frontend improvements

### DIFF
--- a/app/assets/images/terms-desk-blur-left.svg
+++ b/app/assets/images/terms-desk-blur-left.svg
@@ -1,0 +1,12 @@
+<svg width="487" height="440" viewBox="0 0 487 440" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.5" filter="url(#filter0_f_44223_18843)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M173.889 108.91C193.661 100.602 216.017 109.734 237.623 107.794C267.607 105.101 297.722 79.1753 324.611 95.3744C350.868 111.193 351.473 149.881 357.728 180.151C363.694 209.023 371.022 239.542 359.777 265.546C348.718 291.121 325.03 309.675 298.621 316.835C275.124 323.206 251.542 306.462 227.045 301.532C205.136 297.123 180.611 304.187 162.819 289.506C144.808 274.644 142.352 248.714 135.774 226.222C128.873 202.627 116.356 178.203 123.678 155.668C131.117 132.771 152.308 117.977 173.889 108.91Z" fill="#9ABEE3"/>
+</g>
+<defs>
+<filter id="filter0_f_44223_18843" x="0.453552" y="-30.915" width="486.191" height="470.177" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="60.5" result="effect1_foregroundBlur_44223_18843"/>
+</filter>
+</defs>
+</svg>

--- a/app/assets/images/terms-desk-blur-right.svg
+++ b/app/assets/images/terms-desk-blur-right.svg
@@ -1,0 +1,12 @@
+<svg width="442" height="430" viewBox="0 0 442 430" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.3" filter="url(#filter0_f_44223_18842)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M307.152 144.524C313.906 161.976 305.385 181.248 306.54 200.141C308.143 226.361 330.006 253.273 315.208 276.323C300.758 298.832 266.998 298.396 240.441 303.099C215.11 307.585 188.308 313.217 165.907 302.762C143.875 292.48 128.281 271.358 122.693 248.145C117.721 227.492 132.912 207.34 137.821 186.095C142.212 167.096 136.661 145.529 149.908 130.376C163.319 115.036 185.997 113.539 205.779 108.361C226.53 102.929 248.144 92.619 267.618 99.5658C287.404 106.624 299.78 125.475 307.152 144.524Z" fill="#FC8383"/>
+</g>
+<defs>
+<filter id="filter0_f_44223_18842" x="0.706421" y="-23.7603" width="440.616" height="453.459" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="60.5" result="effect1_foregroundBlur_44223_18842"/>
+</filter>
+</defs>
+</svg>

--- a/app/assets/images/terms-mob-blur-left.svg
+++ b/app/assets/images/terms-mob-blur-left.svg
@@ -1,0 +1,12 @@
+<svg width="366" height="369" viewBox="0 0 366 369" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.5" filter="url(#filter0_f_44223_18845)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M52.8136 37.9097C72.5858 29.6023 94.9419 38.734 116.547 36.7938C146.532 34.1011 176.647 8.17531 203.535 24.3744C229.793 40.1933 230.397 78.8813 236.653 109.151C242.619 138.023 249.947 168.542 238.702 194.546C227.642 220.121 203.955 238.675 177.545 245.835C154.048 252.206 130.467 235.462 105.969 230.532C84.0604 226.123 59.5357 233.187 41.7435 218.506C23.7326 203.644 21.2762 177.714 14.6983 155.222C7.79789 131.627 -4.71902 107.203 2.60268 84.6683C10.042 61.7713 31.2328 46.9769 52.8136 37.9097Z" fill="#9ABEE3"/>
+</g>
+<defs>
+<filter id="filter0_f_44223_18845" x="-120.622" y="-101.915" width="486.191" height="470.177" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="60.5" result="effect1_foregroundBlur_44223_18845"/>
+</filter>
+</defs>
+</svg>

--- a/app/assets/images/terms-mob-blur-right.svg
+++ b/app/assets/images/terms-mob-blur-right.svg
@@ -1,0 +1,12 @@
+<svg width="277" height="377" viewBox="0 0 277 377" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.3" filter="url(#filter0_f_44223_18844)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M307.152 91.5238C313.906 108.976 305.385 128.248 306.54 147.141C308.143 173.361 330.006 200.273 315.208 223.323C300.758 245.832 266.998 245.396 240.441 250.099C215.11 254.585 188.308 260.217 165.907 249.762C143.875 239.48 128.281 218.358 122.693 195.145C117.721 174.492 132.912 154.34 137.821 133.095C142.212 114.096 136.661 92.5292 149.908 77.3757C163.319 62.0359 185.997 60.5385 205.779 55.3607C226.53 49.929 248.144 39.619 267.618 46.5658C287.404 53.6241 299.78 72.4752 307.152 91.5238Z" fill="#FC8383"/>
+</g>
+<defs>
+<filter id="filter0_f_44223_18844" x="0.706421" y="-76.7603" width="440.616" height="453.459" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="60.5" result="effect1_foregroundBlur_44223_18844"/>
+</filter>
+</defs>
+</svg>

--- a/app/views/terms_and_conditions/show.html.slim
+++ b/app/views/terms_and_conditions/show.html.slim
@@ -1,8 +1,20 @@
 div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
-  h2 class="px-12 pt-10 pb-6 text-2xl font-bold text-center uppercase md:pt-24 md:pb-9 text-gray-gray-7"
-    | Giving Connection Terms of Use
-  p class="pb-4 text-center"
-    ' Last Updated: February 15, 2022
+
+  div class="flex mx-auto flex-row max-w-7xl justify-evenly"
+    div class="relative flex flex-col justify-center text-center md:mx-0"
+      div class="max-w-md mx-auto"
+        h2 class="pt-14 sm:pt-32 text-2xl font-bold text-center uppercase text-gray-gray-7"
+          | Giving Connection Terms of Use
+        p class="max-w-xl pt-10 pb-9 px-3 sm:px-0 mx-auto text-center text-gray-3 text-base"
+          ' Last Updated: February 15, 2022
+      div class="hidden sm:block sm:absolute -top-20 -left-32 -z-1"
+        = inline_svg_tag 'terms-desk-blur-left.svg'
+      div class="hidden overflow-hidden sm:block sm:absolute -top-20 -right-28 -z-1"
+        = inline_svg_tag 'terms-desk-blur-right.svg'
+      div class="absolute -left-6 -z-1 sm:hidden -top-20"
+        = inline_svg_tag 'terms-mob-blur-left.svg', size:'320*428'
+      div class="absolute -right-6 overflow-visible -top-28 -z-1 sm:hidden"
+        = inline_svg_tag 'terms-mob-blur-right.svg'
   p class="pb-4"
     ' Giving Connection Inc ("Giving Connection," "we," "us," or "our") welcomes you to our website. We are a tax exempt,
     ' IRS Section 501(c)(3) nonprofit organization that seeks to connect people with nonprofits in their communities using


### PR DESCRIPTION
### What Changed
- Add color blur svg files for desktop and mobile.
- Create color splash section for header.



### References

- Before
<img width="1055" alt="Screen Shot 2022-05-27 at 14 28 39" src="https://user-images.githubusercontent.com/63365501/170777709-9bb1d8e1-3aa6-432e-a947-83e4ca2c3b1e.png">

- After
<img width="1105" alt="Screen Shot 2022-05-27 at 14 26 49" src="https://user-images.githubusercontent.com/63365501/170777485-cc3fd16f-5c8e-4cb0-a37c-ac176da9d583.png">


- [Notion](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=80a117abb0b440dc8112217b7c4f8f51)