### PR TITLE
Feature | Fix privacy links

### DIFF
--- a/app/views/privacy_policies/show.html.slim
+++ b/app/views/privacy_policies/show.html.slim
@@ -141,11 +141,12 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
       ' b.
       span class="underline"
         ' Google Maps.
+      ' The Google Maps terms of service can be reviewed
       a class="text-blue-medium" target="_blank" href="https://cloud.google.com/maps-platform/terms"
-        ' Click here to open Google Maps privacy policy
-      ' and
+        ' here
+      ' and the Google privacy policy can be reviewed
       a class="text-blue-medium" target="_blank" href="http://www.google.com/policies/privacy/"
-        ' click here to open Google Privacy Policy.
+        ' here.
 
     li class="pb-2"
       ' c.
@@ -159,8 +160,9 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
       ' d.
       span class="underline"
         ' Givebutter.
+      ' The Givebutter privacy policy can be reviewed
       a class="text-blue-medium" target="_blank" href="https://givebutter.com/privacy"
-        ' Click here to open Givebutter privacy policy.
+        ' here.
     li class="pb-2"
       ' e.
       span class="underline"
@@ -170,22 +172,25 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
       ' f.
       span class="underline"
         ' Mailchimp.
+      ' The Mailchimp privacy policy can be reviewed
       a class="text-blue-medium" target="_blank" href="https://mailchimp.com/legal/privacy/"
-        ' Click here to open Mailchimp privacy policy.
+        ' here.
 
     li class="pb-2"
       ' g.
       span class="underline"
         ' PayPal.
+      ' The Paypal privacy policy can be reviewed
       a class="text-blue-medium" target="_blank" href="https://www.paypal.com/us/webapps/mpp/ua/privacy-full"
-        ' Click here to open PayPal privacy policy.
+        ' here.
 
     li class="pb-2"
       ' h.
       span class="underline"
         ' Instagram.
+      ' The Instagram privacy policy can be reviewed
       a class="text-blue-medium" target="_blank" href="https://help.instagram.com/519522125107875"
-        ' Click here to open Instagram privacy policy.
+        ' here.
     li class="pb-2"
       ' i.
       span class="underline"


### PR DESCRIPTION
### Context
Added open new tab to privacy links. Fixed email link (it didn't open the mailer). Add href to telephone number so it opens up phone when clicked. Hid URLs on text so they don't affect the styling.

### Reference 
- [Notion](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=d06b7ad6f5bb44e297a87e5a4eb00b2e)