### PR TITLE
Feature | Add color splash on Privacy policy page

### DIFF
--- a/app/assets/images/donor-desk-blur-left.svg
+++ b/app/assets/images/donor-desk-blur-left.svg
@@ -1,0 +1,12 @@
+<svg width="418" height="354" viewBox="0 0 418 354" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.3" filter="url(#filter0_f_44792_16602)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M275.457 188.233C264.891 198.129 248.6 197.593 235.38 203.889C217.034 212.626 204.055 236.099 183.237 232.153C162.907 228.3 153.45 203.955 142.391 186.264C131.842 169.39 120.046 151.792 121.064 132.696C122.064 113.915 132.705 96.6157 147.74 85.8892C161.118 76.3458 179.971 81.412 196.632 78.7862C211.533 76.4378 225.398 66.2145 240.103 71.333C254.988 76.5144 262.625 92.3501 272.064 105.043C281.966 118.358 295.617 130.881 296.269 146.861C296.931 163.098 286.989 177.432 275.457 188.233Z" fill="#FC8383"/>
+</g>
+<defs>
+<filter id="filter0_f_44792_16602" x="0.00195312" y="-51.0834" width="417.298" height="404.679" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="60.5" result="effect1_foregroundBlur_44792_16602"/>
+</filter>
+</defs>
+</svg>

--- a/app/assets/images/donor-desk-blur-right.svg
+++ b/app/assets/images/donor-desk-blur-right.svg
@@ -1,0 +1,12 @@
+<svg width="461" height="399" viewBox="0 0 461 399" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.6" filter="url(#filter0_f_44793_16859)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M139.401 140.991C150.382 126.819 170.41 124.282 185.341 113.992C206.064 99.7118 217.335 68.4639 243.567 69.209C269.182 69.9366 285.518 97.8536 302.509 117.32C318.716 135.887 336.59 155.095 339.088 178.647C341.545 201.809 331.924 225.05 315.639 241.113C301.151 255.406 277.104 252.905 257.243 259.382C239.482 265.174 224.53 280.393 205.545 277.016C186.327 273.597 173.884 255.729 159.854 242.057C145.135 227.714 125.988 215.077 122.059 195.663C118.067 175.937 127.416 156.459 139.401 140.991Z" fill="#9AE2E0"/>
+</g>
+<defs>
+<filter id="filter0_f_44793_16859" x="0.123535" y="-51.8041" width="460.345" height="450.303" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="60.5" result="effect1_foregroundBlur_44793_16859"/>
+</filter>
+</defs>
+</svg>

--- a/app/assets/images/donor-mob-blur-left.svg
+++ b/app/assets/images/donor-mob-blur-left.svg
@@ -1,0 +1,12 @@
+<svg width="332" height="325" viewBox="0 0 332 325" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.3" filter="url(#filter0_f_44793_16860)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M189.457 159.552C178.891 169.448 162.6 168.912 149.38 175.208C131.034 183.945 118.055 207.418 97.2366 203.472C76.9071 199.619 67.4498 175.274 56.3906 157.583C45.8423 140.709 34.0458 123.111 35.0635 104.015C36.0645 85.2344 46.7046 67.9347 61.7404 57.2083C75.118 47.6648 93.9706 52.7311 110.632 50.1052C125.533 47.7569 139.398 37.5336 154.103 42.6521C168.988 47.8335 176.625 63.6691 186.064 76.3622C195.966 89.6775 209.617 102.2 210.269 118.18C210.931 134.417 200.989 148.751 189.457 159.552Z" fill="#FC8383"/>
+</g>
+<defs>
+<filter id="filter0_f_44793_16860" x="-85.998" y="-79.7643" width="417.298" height="404.679" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="60.5" result="effect1_foregroundBlur_44793_16860"/>
+</filter>
+</defs>
+</svg>

--- a/app/assets/images/donor-mob-blur-right.svg
+++ b/app/assets/images/donor-mob-blur-right.svg
@@ -1,0 +1,12 @@
+<svg width="314" height="370" viewBox="0 0 314 370" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.6" filter="url(#filter0_f_44793_16861)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M139.401 112.31C150.382 98.1384 170.41 95.6007 185.341 85.3109C206.064 71.0308 217.335 39.7829 243.567 40.528C269.182 41.2556 285.518 69.1726 302.509 88.6391C318.716 107.206 336.59 126.414 339.088 149.966C341.545 173.128 331.924 196.369 315.639 212.433C301.151 226.725 277.104 224.224 257.243 230.701C239.482 236.493 224.53 251.712 205.545 248.335C186.327 244.916 173.884 227.048 159.854 213.376C145.135 199.033 125.988 186.396 122.059 166.982C118.067 147.256 127.416 127.778 139.401 112.31Z" fill="#9AE2E0"/>
+</g>
+<defs>
+<filter id="filter0_f_44793_16861" x="0.123535" y="-80.4851" width="460.345" height="450.303" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="60.5" result="effect1_foregroundBlur_44793_16861"/>
+</filter>
+</defs>
+</svg>

--- a/app/views/privacy_policies/show.html.slim
+++ b/app/views/privacy_policies/show.html.slim
@@ -274,10 +274,26 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
   p class="pb-4"
     ' Our intent is to promptly reply to every message we receive. This information is used to respond directly to your questions or comments. We also may file your comments to improve our services in the future.
 
+  div class="flex mx-auto flex-row max-w-7xl justify-evenly"
+    div class="relative flex flex-col justify-center text-center md:mx-0"
+      div class="max-w-lg mx-auto"
+        h2 class="pt-10 pb-6 mdpx:pt-24 525px:pb-9 text-2xl font-bold text-center uppercase text-gray-gray-7"
+          | Donor Privacy Policy
 
+      div class="absolute -left-6 -top-16 xs:-left-10 -z-1 425px:hidden "
+        = inline_svg_tag 'donor-mob-blur-left.svg', size:'300*325'
+      div class="absolute -right-7 -top-32 xs:-right-11 overflow-visible -z-1 425px:hidden"
+        = inline_svg_tag 'donor-mob-blur-right.svg'
 
-  h2 class="px-12 pt-10 pb-6 text-2xl font-bold text-center uppercase md:pt-24 md:pb-9 text-gray-gray-7"
-    | Donor Privacy Policy
+      div class="hidden 425px:block 425px:absolute -top-20 -left-10 -z-1"
+        = inline_svg_tag 'donor-desk-blur-left.svg', size:'250*250'
+      div class="hidden overflow-hidden 425px:block 425px:absolute -top-12 -right-10 -z-1"
+        = inline_svg_tag 'donor-desk-blur-right.svg', size:'250*250'
+
+      div class="hidden md:block md:absolute -top-18 -left-52 -z-1"
+        = inline_svg_tag 'donor-desk-blur-left.svg'
+      div class="hidden overflow-hidden md:block md:absolute -top-36 -right-38 -z-1"
+        = inline_svg_tag 'donor-desk-blur-right.svg'
 
   p class="pb-4"
     '   Giving Connection is committed to respecting the privacy of our donors.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
   theme: {
     screens: {
       'xs': '375px',
+      '425px': '425px',
       '525px': '525px',
       'mid': '870px',
       ...screens,


### PR DESCRIPTION
## What changed
- Create color splash for "Donor Privacy Policy" header on privacy policy page.

## References

<img width="1005" alt="Screen Shot 2022-06-03 at 16 37 36" src="https://user-images.githubusercontent.com/63365501/171957211-292b8bf7-654f-404c-a034-f602ff446f93.png">

[Notion](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=857f172470e14ba6826cc72c1ebaf933)