### PR TITLE
Feature | Save favorite locations after redirect

### DIFF
--- a/app/components/result_card/component.html.erb
+++ b/app/components/result_card/component.html.erb
@@ -20,7 +20,7 @@
             <%= render 'shared/unmarked', id: @id %>
           <% end %>
         <% else %>
-          <%= link_to new_user_registration_path, class: "inline-flex items-center p-2 text-xs text-gray-3" do %>
+          <%= link_to favorite_locations_path(location_id: @id), method: :post, class: "inline-flex items-center p-2 text-xs text-gray-3" do %>
             <%= inline_svg_tag 'bookmark_empty.svg', class: 'w-4 h-4' %>
           <% end %>
         <% end %>

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,7 +30,15 @@ class ApplicationController < ActionController::Base
      store_location_for(:user, request.fullpath)
    end
 
-   def after_sign_in_path_for(resource_or_scope)
-     stored_location_for(resource_or_scope) || super
-   end
+  def after_sign_in_path_for(resource_or_scope)
+    create_instances_from_session
+    stored_location_for(resource_or_scope) || super
+  end
+
+  def create_instances_from_session
+    if session[:fav_loc_id].present?
+      FavoriteLocation.create(location_id: session[:fav_loc_id], user: current_user)
+      session.delete(:fav_loc_id)
+    end
+  end
 end

--- a/app/controllers/favorite_locations_controller.rb
+++ b/app/controllers/favorite_locations_controller.rb
@@ -2,6 +2,7 @@
 
 class FavoriteLocationsController < ApplicationController
   skip_before_action :authenticate_user!
+  before_action :set_session_favorite
 
   include Pundit
 
@@ -14,24 +15,31 @@ class FavoriteLocationsController < ApplicationController
     if new_favorite_location.save
       if params["origin"] == "location_show"
         redirect_to location_path(@location)
-      else 
-        data = { marked_partial: render_to_string(partial: "shared/marked", locals: { user_id: current_user, id: @location.id }), 
-                 location_id: @location.id, method: "create" }
-        ActionCable.server.broadcast("everyone", data)
       end
+      data = { marked_partial: render_to_string(partial: "shared/marked", locals: { user_id: current_user, id: @location.id }), 
+                location_id: @location.id, method: "create" }
+      ActionCable.server.broadcast("everyone", data)
     end
   end
 
   def destroy
-    @favorite_location = FavoriteLocation.find(params[:id])
+    @favorite_location = current_user.fav_locs.find(params[:id])
     if @favorite_location.destroy
       if params["origin"] == "location_show"
         redirect_to location_path(@favorite_location.location)
-      else 
-        data = { unmarked_partial: render_to_string(partial: "shared/unmarked", locals: { id: @favorite_location.location.id }), 
-                 location_id: @favorite_location.location.id, favorite_location_id: @favorite_location.id }
-        ActionCable.server.broadcast("everyone", data)
       end
+      data = { unmarked_partial: render_to_string(partial: "shared/unmarked", locals: { id: @favorite_location.location.id }), 
+                 location_id: @favorite_location.location.id, favorite_location_id: @favorite_location.id }
+      ActionCable.server.broadcast("everyone", data)
+    end
+  end
+
+  private
+
+  def set_session_favorite
+    unless user_signed_in?
+      session[:fav_loc_id] = params[:location_id]
+      redirect_to user_session_path
     end
   end
 end

--- a/app/views/locations/show.html.slim
+++ b/app/views/locations/show.html.slim
@@ -30,8 +30,9 @@ div class=""
                 = inline_svg_tag "bookmark_empty.svg", class: "w-4 h-4 mr-2"
                 | Save
           - else
-            = link_to new_user_registration_path, class: "inline-flex items-center p-2 text-xs text-gray-3" do
-              = inline_svg_tag 'bookmark_empty.svg', class: "w-4 h-4 mr-2"          
+            = link_to favorite_locations_path(location_id: @location.id), method: :post, class: "inline-flex items-center p-2 text-sm text-gray-3" do
+              = inline_svg_tag 'bookmark_empty.svg', class: "w-4 h-4 mr-2"
+              | Save
         - if @location.causes.present?
           div class="flex my-8 gap-2.5 flex-wrap px-6"
             - @location.organization.causes.uniq.each do |cause|

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -37,7 +37,7 @@
                 = inline_svg_tag "bell.svg", class: 'h-3 w-3 mr-2 fill-current text-gray-2 -ml-0.5'
                 | Create Search Alert
             - else
-              = link_to new_user_registration_path, class: 'inline-flex items-center px-3 py-2 text-xs text-gray-3' do
+              = link_to user_session_path, class: 'inline-flex items-center px-3 py-2 text-xs text-gray-3' do
                 = inline_svg_tag "bell.svg", class: 'h-3 w-3 mr-2 fill-current text-gray-2 -ml-0.5'
                 | Create Search Alert
           div class="hidden w-full h-full overflow-y-auto md:flex md:flex-col" data-tabs-target="panel"
@@ -73,7 +73,7 @@
                   button class="mt-10 text-sm font-bold text-black" type="button" data-action="click->modal#open"
                     | Create an Alert for this Search
                 - else
-                  = link_to new_user_registration_path, class: 'mt-10 text-sm font-bold text-black'
+                  = link_to user_session_path, class: 'mt-10 text-sm font-bold text-black'
                     | Create an Alert for this Search
           = render SearchAlert::Component.new(keywords: params.dig('search', 'keyword'), filters: list_of_filters(@search))
         div class="hidden w-full h-85vh md:h-0" data-tabs-target="panel" data-controller="places" data-action="google-maps-callback@window->places#initMap" data-places-imageurl-value="#{asset_path 'markergc.png'}"
@@ -84,19 +84,19 @@
               div class="hidden" data-places-target="longitude"
               div class="flex flex-col items-center gap-2 p-3 text-center bg-white rounded-6px" data-places-target="marker" data-latitude="#{result.latitude}" data-longitude="#{result.longitude}" data-po_box="#{result.po_box}"
                 - if user_signed_in?
-                  - if !FavoriteLocation.exists?(user_id: current_user.id, location_id: result.id)
+                  - if !current_user.favorited_locations.include?(result)
                     = link_to favorite_locations_path(location_id: result.id), class: "inline-flex self-end text-xs text-gray-3", type: "button", method: :post, remote: true do
                       = inline_svg_tag 'bookmark_empty.svg', class: 'w-4 h-4'
                   - else
-                    = link_to favorite_location_path(FavoriteLocation.find_by(user_id: current_user.id, location_id: result.id)), method: :delete, class: "inline-flex self-end text-xs text-gray-3", remote: true do
+                    = link_to favorite_location_path(current_user.fav_locs.find_by(location_id: result.id)), method: :delete, class: "inline-flex self-end text-xs text-gray-3", remote: true do
                       = inline_svg_tag 'bookmark_colored.svg', class: 'w-4 h-4'
                 - else
-                  = link_to user_session_path, class: "inline-flex self-end text-xs text-gray-3" do
+                  = link_to favorite_locations_path(location_id: result.id), method: :post, class: "inline-flex self-end text-xs text-gray-3" do
                     = inline_svg_tag 'bookmark_empty.svg', class: 'w-4 h-4'
                 h5 class="text-lg font-bold leading-6 text-gray-2"
                   = link_to result.name, location_path(result)
                 p class="text-xs text-gray-4"
-                  = link_to result.address, result.link_to_google_maps, target: "blank" 
+                  = link_to result.address, result.link_to_google_maps, target: "blank"
                 p class="text-xs text-blue-medium"
                   = link_to result.organization.website, "http://#{result.organization.website}", target:"_blank"
                 - if device == "mobile"
@@ -126,15 +126,15 @@
             div class="hidden" data-places-target="longitude"
             div class="flex flex-col items-center gap-2 p-3 text-center bg-white rounded-6px" data-places-target="marker" data-latitude="#{result.latitude}" data-longitude="#{result.longitude}"
               - if user_signed_in?
-                - if !FavoriteLocation.exists?(user_id: current_user.id, location_id: result.id)
+                - if !current_user.favorited_locations.include?(result)
                   = link_to favorite_locations_path(location_id: result.id), class: "inline-flex self-end text-xs text-gray-3", type: "button", method: :post, remote: true, data: { action:"click->result-card--component#reloadPage" }do
                     = inline_svg_tag 'bookmark_empty.svg', class: 'w-4 h-4'
                 - else
-                  = link_to favorite_location_path(FavoriteLocation.find_by(user_id: current_user.id, location_id: result.id)), method: :delete, class: "inline-flex self-end text-xs text-gray-3", remote: true, data: { action:"click->result-card--component#reloadPage" } do
+                  = link_to favorite_location_path(current_user.fav_locs.find_by(location_id: result.id)), method: :delete, class: "inline-flex self-end text-xs text-gray-3", remote: true, data: { action:"click->result-card--component#reloadPage" } do
                     = inline_svg_tag 'bookmark_colored.svg', class: 'w-4 h-4'
               - else
-                = link_to user_session_path, class: "inline-flex self-end text-xs text-gray-3" do
-                  = inline_svg_tag 'bookmark_empty.svg', class: 'w-4 h-4'
+                = link_to favorite_locations_path(location_id: result.id), method: :post, class: "inline-flex self-end text-xs text-gray-3" do
+                    = inline_svg_tag 'bookmark_empty.svg', class: 'w-4 h-4'
               h5 class="text-lg font-bold leading-6 text-gray-2" id="pointer"
                 = link_to result.name, location_path(result)
               p class="text-xs text-gray-4"


### PR DESCRIPTION
### Context 
If the user likes a location and is redirected to log in or sign up. The user must be able to do so and the location must be saved after the sign-in. 

### Testing
- Log out
- Add one location to favorites (in any page)
- Log in
- See if the location was saved

### Reference 
- [Notion](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=9ae5902dd1d04da9863ebc77c202f783)