### PR TITLE
Feature | Add message content to email

### DIFF
--- a/app/views/message_mailer/default_response.html.slim
+++ b/app/views/message_mailer/default_response.html.slim
@@ -1,9 +1,8 @@
 h2 Thank you for contacting us.
+h2 We will get back to you as soon as we can.
+
+h3 The Giving Connection Team
 br
 p Your message was:
 p style="color:grey"
   ' #{@message.content}
-br
-h2 We will get back to you as soon as we can.
-
-h3 The Giving Connection Team


### PR DESCRIPTION
### Context
By request, we must include the email message to the email.

### Test
Go to Contact Us or Add a Nonprofit and send a message.
You should receive an email with the copy of you message.

### Reference

-[Notion](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=af46d65259d649f7a51f527c1cbc1559)

<img width="638" alt="image" src="https://user-images.githubusercontent.com/76601125/174886000-ca5b9f13-86a5-4eab-83b6-ae6d0fed3139.png">
