### PR TITLE
Feature | Improve keyword search functionality

### DIFF
--- a/app/models/locations/searchable.rb
+++ b/app/models/locations/searchable.rb
@@ -9,7 +9,7 @@ module Locations
       pg_search_scope :search_by_keyword,
                       against: {
                         name: 'A',
-                        address: 'E'
+                        address: 'D'
                       },
                       associated_against: {
                         causes: { name: 'B' },


### PR DESCRIPTION
## Context
Result prioritization does not work correctly when searching by keyword. For example, if you search using "Mental Health," the matching location name does not appear first.

## What changed
The priority should go in this order Name -> Causes -> Services -> Keywords/Tags -> Populations Served -> NTEE Code -> Mission - What We Do/Vision - Goals and Aspirations/Services - How We Do It -> Everything else.

The new order was implemented only using Name -> Causes -> Services -> Keywords/Tags because PG provides only 4 letters ("A", "B", "C", or "D".) for weighting.

[PG search weighting](https://github.com/Casecommons/pg_search#:~:text=in%20multiple%20languages.-,weighting,-Each%20searchable%20column)