### PR TITLE
Feature/ prevent multiple map card from rendering

### DIFF
--- a/app/javascript/controllers/places_controller.js
+++ b/app/javascript/controllers/places_controller.js
@@ -65,6 +65,8 @@ export default class extends Controller {
 
   setMarkers(map, image) {
     // Adds markers to the map.
+    let prevInfoWindow = false
+
     for (let i = 0; i < this.markerTargets.length; i++) {
       const element = this.markerTargets[i];
       const latitudeTarget = Number(element.dataset.latitude)
@@ -82,6 +84,12 @@ export default class extends Controller {
       });
 
       marker.addListener("click", () => {
+        if( prevInfoWindow ) {
+          prevInfoWindow.close()
+        }
+
+        prevInfoWindow = infowindow
+
         infowindow.open({
           anchor: marker,
           map,


### PR DESCRIPTION
## Context
On searches page, when clicking two or more location pins on the map, all information cards show at once.

## What changed
Modified setMarkers function on places controller to store the last InfoWindow object and close it when a new one has been clicked.

##
![hurr](https://user-images.githubusercontent.com/7217429/175116969-3ee4b11d-2ae9-4ca0-81a5-a4ea0799d980.gif)


## Reference
[Notion](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=ac55b8301255481eb9572cfbd39cb0e0)