### PR TITLE
Feature | Add embed youtube video to about us page

### DIFF
--- a/app/views/about_us/show.html.slim
+++ b/app/views/about_us/show.html.slim
@@ -465,7 +465,7 @@ div class="flex flex-col text-gray-2"
         end
       end
     div class="w-full max-w-4xl pb-12 mb-16 h-full"
-      iframe src="https://www.youtube.com/embed/H62FCqZ1cAg?rel=0" class="w-full h-64 md:h-96" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      iframe src="https://www.youtube.com/embed/H62FCqZ1cAg?rel=0" class="w-full h-64 md:h-500px" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
 
 
   div class="relative bg-seafoam h-96"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -102,6 +102,7 @@ module.exports = {
         '350px': '350px',
         '400px': '400px',
         '85vh': '85vh',
+        '500px': '500px',
       },
       borderRadius: {
         '6px': '6px',


### PR DESCRIPTION
## Context
Add embed youtube video to about us page

## What changed
Added a new iframe below the BioCards to embed a youtube video.

## Images
Desktop
![imagen](https://user-images.githubusercontent.com/7217429/176244349-a39f7907-4c3d-4660-b03c-e8448a864478.png)
Mobile
![imagen](https://user-images.githubusercontent.com/7217429/176244753-53720322-f574-414d-9583-3758970d13b5.png)



## Reference
[Notion](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=56b12db05d714eb3a3c0ebcf4cc63764)
