### PR TITLE
Feature | Link button to donor privacy policy section

### DIFF
--- a/app/views/privacy_policies/show.html.slim
+++ b/app/views/privacy_policies/show.html.slim
@@ -6,6 +6,7 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
           | Giving Connection Privacy Policy
         p class="max-w-xl pt-10 pb-9 px-3 sm:px-0 mx-auto text-center text-gray-3 text-base"
           ' Last Updated: February 15, 2022
+        =link_to "go to donor privacy policy", '#donor_policy', class:'c-button py-2.5 px-5 text-white bg-blue-medium mb-8 w-fit'
       div class="hidden sm:block sm:absolute -top-20 -left-32 -z-1"
         = inline_svg_tag 'privacy-desk-blur-left.svg'
       div class="hidden overflow-hidden sm:block sm:absolute -top-28 -right-36 -z-1"
@@ -281,7 +282,7 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
   p class="pb-4"
     ' Our intent is to promptly reply to every message we receive. This information is used to respond directly to your questions or comments. We also may file your comments to improve our services in the future.
 
-  div class="flex mx-auto flex-row max-w-7xl justify-evenly"
+  div id="donor_policy" class="flex mx-auto flex-row max-w-7xl justify-evenly"
     div class="relative flex flex-col justify-center text-center md:mx-0"
       div class="max-w-lg mx-auto"
         h2 class="pt-10 pb-6 mdpx:pt-24 525px:pb-9 text-2xl font-bold text-center uppercase text-gray-gray-7"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -84,6 +84,9 @@ module.exports = {
         '656px': '656px',
         ms: '343px'
       },
+      width: {
+        fit: 'fit-content',
+      },
       minHeight: {
         '46px': '46px',
         '800px': '800px',


### PR DESCRIPTION
## Context
The donor privacy policy section was hard to reach by scrolling on the `privacy policy` page.

## What changed
Added a link button that points to the donor privacy policy section `div`.

## Images
Mobile:
![imagen](https://user-images.githubusercontent.com/7217429/176319995-3b6b0ec8-b71d-41e6-ba25-d2e15fa1cec6.png)
Desktop:
![imagen](https://user-images.githubusercontent.com/7217429/176320191-c453964b-bbd1-4781-967e-0dabd2dd092e.png)

## References
[Notion](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=195649131f92458694746b8728d782de)
[Figma](https://www.figma.com/file/NRLaybtbOQyWAw7xgziSHh/GC---UI?node-id=44223%3A15770)
