### PR TITLE
Fix | Set max-width on results panel

### DIFF
--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -3,7 +3,7 @@
   = render SearchBar::Component.new(form: f, search: @search)
   div class="flex flex-row justify-center w-full md:h-85vh" data-controller="tabs" data-tabs-active-tab="border-blue-dark bg-blue-dark text-white" data-tabs-inactive-tab="border-gray-6 bg-transparent text-gray-3"
     div class="flex flex-row justify-center w-full min-h-full"
-      div class="flex flex-col w-full md:border-r border-gray-7"
+      div class="flex flex-col w-full md:border-r max-w-470px border-gray-7"
         div class="flex flex-row justify-between w-full p-4 bg-gray-9" data-controller="modal"
           button class="inline-flex items-center px-3 py-2 text-sm leading-4" type="button" data-action="click->modal#open"
             /! Heroicon name: solid/mail


### PR DESCRIPTION
## Context
Results panel was missing a `max-width` style

## What Changed
Added missing style `max-w-470px`