### PR TITLE
Fix | Update clock

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -23,7 +23,7 @@ module Clockwork
     end
   end
 
-  every(1.day, 'Fetch Instagram Media Posts', at: '22:00') do
+  every(3.hours, 'Fetch Instagram Media Posts') do
     Instagram::FetchMediaPostsJob.perform_later
   end
 end


### PR DESCRIPTION
### Context
Update Instagram posts every 3 hours