### PR TITLE
Hotfix | Remove required name field

### DIFF
--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -25,7 +25,7 @@ div class="w-full h-full bg-grey-9"
 
           div class="col-span-12 lg:col-span-6 md:col-span-7"
             = f.label :name, "* Organization Name", class: "block text-sm text-gray-3 font-medium"
-            = f.text_field :name, { class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }, required: true
+            = f.text_field :name, { class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }
 
             div class="flex items-center mt-3"
               = check_box_tag :other_name_check, true, false, class: " h-4 w-4 mt-1 mr-2 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent ", data: { action: "toggle#toggle" }


### PR DESCRIPTION
## Context
There was a problem with the edit organization form name text field where the required attribute was giving errors

## What changed
Removed required attribute