### PR TITLE
Fix broken empty state

### DIFF
--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -74,8 +74,7 @@
                   button class="mt-10 text-sm font-bold text-black" type="button" data-action="click->modal#open"
                     | Create an Alert for this Search
                 - else
-                  = link_to user_session_path, class: 'mt-10 text-sm font-bold text-black'
-                  | Create an Alert for this Search
+                  = link_to "Create an Alert for this Search", user_session_path, class: 'mt-10 text-sm font-bold text-black'
           = render SearchAlert::Component.new(keywords: params.dig('search', 'keyword'), filters: list_of_filters(@search))
         div class="hidden w-full h-85vh md:h-0" data-tabs-target="panel" data-controller="places" data-action="google-maps-callback@window->places#initMap" data-places-imageurl-value="#{asset_path 'markergc.png'}"
           div# class="w-full h-full" data-places-target="map"


### PR DESCRIPTION
The empty state when the user is not signed in seems broken. See below.
![Giving_Connection](https://user-images.githubusercontent.com/1545278/187571865-fa84a3f9-d60b-4ae6-a6b1-9ef8e00733ab.jpg)

This fix changes it so the users/sign_up path is used as a link for the "Create alert", as it seems is the intended behavior.