### PR TITLE
Privacy Button Bug

### DIFF
--- a/app/views/privacy_policies/show.html.slim
+++ b/app/views/privacy_policies/show.html.slim
@@ -211,8 +211,7 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
   ol class="pl-10 list-disc"
     li class="pb-2"
       ' All of your User Content, as defined in our
-      a class="text-blue-medium" href="https://www.givingconnection.org/termsofuse"
-        | Terms of Use
+      = link_to 'Terms of Use', terms_of_use_path, class: "text-blue-medium"
       ' , on the Platform will be publicly viewable and shareable by other users both within and outside the Platform.
     li class="pb-2"
       ' We may from time to time share Nonprofit Representative Users’ Personal Information and Other Information with other companies who may provide such users information about the products and services they offer. However, to the extent required by law, such users will be given the opportunity to opt-out of such sharing by contacting us as described in the “Contact Us” section below.


### PR DESCRIPTION
### What changed:

- Privacy Policy page had a broken link_to redirecting to terms_of_use, this was changed into two possible options.

### Why this change?:
Wrong coded link_to was causing the page break in staging.

### How to test it:

1. Click on Privacy Policy button at the footer.
2. You should see the page loading well
3. You can also try clicking on Terms of Use links to check they are redirecting well

