### PR TITLE
Frans Podcast redirect link

### DIFF
--- a/app/views/about_us/show.html.slim
+++ b/app/views/about_us/show.html.slim
@@ -288,6 +288,8 @@ div class="flex flex-col text-gray-2"
               ' consideration within the Cape May community has fostered strong relationships characterized by mutual
               ' admiration, respect and care. Gail looks forward to supporting the mission of Giving Connection and
               ' ultimately making the world a better place.
+              br
+              a href="https://www.fransayspodcast.com/" class="font-bold text-blue-medium mt-2" Fran Says..."Listen to my Podcast!❤️
           a data-read-more-target="readMoreButton" data-action="read-more#toggleVisibility" class="font-bold text-blue-medium cursor-pointer" Read More
         end
       end


### PR DESCRIPTION
### What changed:

- Link redirecting to Fran's Podcast was added at the bottom of Gail Wilsey-Morrison Bio.

### Why this change?:
The Bio talks about Fran, Stephanie suggested adding this link to have more information and better access to the podcast.

### How to test it:
1. Click on About Us
2. Search for Gail Wilsey-Morrison and click on Read More...
3. You should see the link at the bottom.

