### PR TITLE
Feature | Google Tag Manager Implementation

### DIFF
--- a/app/assets/javascripts/google_tag_manager.js.erb
+++ b/app/assets/javascripts/google_tag_manager.js.erb
@@ -1,0 +1,7 @@
+document.addEventListener('turbolinks:load', function(event) {
+    if (typeof gtag === 'function') {
+        gtag('config', 'G-23X6N4ZWST', {
+            'page_location': event.data.url
+        })
+    }
+})

--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,11 @@
+<% if Rails.env.production? %>
+<!-- Google tag (gtag.js) -->
+<script async src="[https://www.googletagmanager.com/gtag/js?id=G-23X6N4ZWST](https://www.googletagmanager.com/gtag/js?id=G-23X6N4ZWST)"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-23X6N4ZWST');
+</script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,7 @@
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'https://maps.googleapis.com/maps/api/js?key='+Rails.application.credentials.dig(:google_api_key)+'&libraries=places&callback=initMap', 'data-turbolinks-eval': 'false' %>
+    <%= render 'layouts/google_tag_manager' %>
   </head>
 
   <body class="bg-gray-9">


### PR DESCRIPTION
## Context
GC team wants to track events from users with Google Tag Manager

## What changed
Added partial with GTM configuration and Turbolink event listener, this will only load in production.

## Images
![imagen](https://user-images.githubusercontent.com/7217429/189206722-1201d0c3-8990-4645-8caa-85f9b08af8db.png)

## Reference
[Notion](https://www.notion.so/Google-Analytics-46e572d46b394f68bd3534a17907c700)