### PR TITLE
Fix | Scroll behavior

### DIFF
--- a/app/javascript/controllers/places_controller.js
+++ b/app/javascript/controllers/places_controller.js
@@ -106,6 +106,7 @@ export default class extends Controller {
         });
 
         sessionStorage.setItem('selected_location_id', element.id)
+        this.scrollToSelectedLocation()
       });
 
      if( pin && pin.id == element.id) {


### PR DESCRIPTION
## Context
Auto-scroll was scrolling the parent first and this was causing a weird behavior of over-scrolling the page.

## What changed
Order or execution of the auto-scroll functionality and scroll behavior

## References
[Notion](https://www.notion.so/Open-pin-and-auto-scroll-to-the-last-point-on-search-page-3dc2282164ff45408b8814cf99978de0)