### PR TITLE
Create an Account Auto Scroll

### DIFF
--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,5 +1,5 @@
 .main
-  h2 class="px-12 pb-6 text-2xl font-bold text-center pt-14 md:pt-32 md:mt-2 md:pb-9 text-gray-gray-7"
+  h2 class="px-12 pb-6 text-2xl font-bold text-center pt-14 md:pt-20 md:mt-2 md:pb-9 text-gray-gray-7"
     ' Create an account
     | on Giving Connection
 
@@ -37,7 +37,7 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     .c-form
       = form_group_for f, :name do
-        = f.text_field :name, autofocus: true, autocomplete: "name", class:"c-input"
+        = f.text_field :name, autocomplete: "name", class:"c-input"
       = form_group_for f, :email, label: 'Email Address' do
         = f.email_field :email, autocomplete: "email", class:"c-input"
       = form_group_for f, :password do


### PR DESCRIPTION
### Context
When you headed to the "Create Account" page there was an undesired auto scroll.
### What changed
- The `app/views/registrations/new.html.slim` file - A smaller top padding was set and the `autofocus` property was removed from the first input in the registration form.
### How to test it
hivemind
### References

[Notion ticket](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=105def18e03842899dfc6e51c8636bf1&pm=s)
