### PR TITLE
style<small popup> logo size fixed

### DIFF
--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -86,7 +86,7 @@
                     = link_to favorite_locations_path(location_id: result.id), data: {turbo_method: :post }, class: "inline-flex self-end text-xs text-gray-3" do
                       = inline_svg_tag 'bookmark_empty.svg', class: 'w-4 h-4'
                   div
-                    = image_tag result.organization.logo, class: "w-full h-10"
+                    = image_tag result.organization.logo, class: "w-12 h-12"
                   div
                     a id="pointer"
                       = link_to result.name, location_path(result), target:"_blank", class: "text-small font-bold text-gray-2"
@@ -135,7 +135,7 @@
                   = link_to favorite_locations_path(location_id: result.id), data: { turbo_method: :post }, class: "inline-flex self-end text-xs text-gray-3" do
                     = inline_svg_tag 'bookmark_empty.svg', class: 'w-4 h-4'
                 div
-                  = image_tag result.organization.logo, class: "w-full h-10"
+                  = image_tag result.organization.logo, class: "w-12 h-12"
                 div
                   a id="pointer"
                     = link_to result.name, location_path(result), target:"_blank", class: "text-small font-bold text-gray-2"


### PR DESCRIPTION
### Context
Some logos in the small popups (InfoWindows) had a wrong width

### What changed

With in small popups is now fixed

### How to test it

1. `hivemind`
2. Search Page
3. Open any small `infoWindow`

### References

[Notion ticket](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=67fe2acb766e4e60a04eb702c908efde&p=c2c003628bdd431d946acf5cb7d053f4&pm=s)
