### PR TITLE
Feature/photo quality instructions

### DIFF
--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -238,7 +238,7 @@ div class="w-full h-full bg-grey-9"
                           = link_to inline_svg_tag('trash.svg', class: 'absolute trash bottom-0 top-2.5 right-2.5'), url_for(controller: :organizations, action: :delete_upload, id: @organization.id, upload_id: image.id), data: { confirm: 'Are you sure?' }
                           = image_tag url_for(image), class: "block object-cover rounded-6px m-2 w-20 h-20 lg:w-40 lg:h-40"
                   p class="text-xs text-gray-4 mt-1"
-                    | Submit pictures with png format and horizontal orientation for better results
+                    | For best image quality, please submit horizontal photos in PNG format.
                   = location_form.file_field :images, multiple: true, class: "block mt-2 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 cursor-pointer dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400"
 
                 div class="hidden col-span-3 md:flex"


### PR DESCRIPTION
### Context
Indications for carousel photo qualities was needed.

### What changed
Added text above the submit carousel images button in the edit organization page.

### How to test it
rails db:seed
hivemind
Assign user1 as an admin of any organization I haven't yet, this can be achieved from the admin panel.
Go back to the application and edit one of your organization
Check for the presence of the new text above the the submit carousel images button.

### References

[Notion ticket](https://www.notion.so/Instructions-for-photo-quality-on-My-Nonprofit-Pages-2dfb43cfe29a420eaa691a96e2247909?d=e1aa2d5ad5a145a09a175e6eff816687)
