### PR TITLE
style(places_controller) removed scroll

### DIFF
--- a/app/javascript/controllers/places_controller.js
+++ b/app/javascript/controllers/places_controller.js
@@ -226,7 +226,7 @@ export default class extends Controller {
         });
 
         sessionStorage.setItem('marker_infowindow', element.id)
-        // this.scrollToSelectedLocation()
+        // Scroll method calling was here, removed so that it doesn't scroll on mouseover.
       });
 
       if (pin && pin.id == element.id)  {


### PR DESCRIPTION
### Context
Removing the scroll was needed, when hovering the pins.

### What changed

- [x] [style(places_controller) removed scroll](https://github.com/TelosLabs/giving-connection/commit/d39dc7cce4587c85da6a4d852aa35b6aa8065760)

The method calling was commented, still I decided to leave the method for future usage.
### How to test it

Go to search page and try hovering over map pins

### References

[Notion ticket](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=87b127482b6a4e1787a36b1ab8c267e8&pm=s)
