### PR TITLE
[ON HOLD] FIX |(pills_counter) add correct sum

### DIFF
--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -55,7 +55,7 @@ export default class extends Controller {
   countPills() {
     let pills_count = this.pillsTarget.querySelectorAll("input:checked:not([data-checkbox-select-all-target=checkboxAll])").length
     let advanced_filters_count = this.advancedFiltersTarget.querySelectorAll("input:checked").length
-    if(this.isModalClean() && sessionStorage.getItem("advanced_filters_count") !== null) {
+    if(advanced_filters_count == 0 && sessionStorage.getItem("advanced_filters_count") !== null) {
       advanced_filters_count = sessionStorage.getItem("advanced_filters_count")
       sessionStorage.removeItem('advanced_filters_count')
     }


### PR DESCRIPTION
### Context
When reloading the page, the counter was not counting advanced filters.

### What changed

1. Each time the user saves the advanced filters, the a.filters counter  of the checked A. Filters will be stored so that it can be reused when reload.
2. Added a conditional in the countPills() method to check if the modal is clean but we have a number stored, then here's a discrepancy and we will use the sessionStorage value.
3. Also there was a bug in which the counter was also displaying the All Button, this was also fixed.

### How to test it

1. hivemind
2. Go to the search page
3. Select pills and advanced filters
4. reload the page and you should see the correct sum in counter

### References

[Notion ticket](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=2ca36c051be14b95828ec123bf40c591&pm=s)
