### PR TITLE
bug<searches_helper> refactored and bug is fixed now

### DIFF
--- a/app/helpers/searches_helper.rb
+++ b/app/helpers/searches_helper.rb
@@ -13,22 +13,9 @@ module SearchesHelper
     list.flatten.compact
   end
 
-  def build_params_array(type)
-    arr = params[:search][type.to_sym]
-    arr = arr.values.flatten if type.include?('services') || type.include?('beneficiary_groups')
-    arr
-  end
-
-  def selected_pills(tab_pills, type)
-    search_params = build_params_array(type)
-    search_params & tab_pills
-  end
-
-  def selected_advanced_filters(tab_pills, type)
-    return [] unless params[:search] && params[:search][type].present?
-
-    search_params = build_params_array(type)
-    search_params - tab_pills
+  def selected_(type, top_ten, search)
+    search = search.values.flatten if search.is_a?(Hash)
+    type == 'pills' ? top_ten.map(&:name) & (search) : search - top_ten.map(&:name)
   end
 
   def kilometers_to_miles(kms)

--- a/app/views/searches/_filter.html.slim
+++ b/app/views/searches/_filter.html.slim
@@ -9,33 +9,33 @@ div class="bg-white rounded-3xl" data-search-target="advancedFilters"
       p class="px-6 py-4 text-sm text-gray-4" Add more filters to narrow down your search results.
       div class="px-6 py-8"
         = form.label :causes, 'Causes', class: 'w-full text-base font-bold text-gray-2'
-        - if search.causes
+        - if selected_("pills", @top_10_causes, search.causes || []).any?
           div class='flex items-center gap-1'
             span class="relative inline-flex w-2 h-2 rounded-full bg-green-300"
             p class="text-sm text-gray-4" Selected Pills:
           p class="flex flex-wrap items-center gap-1 text-sm text-gray-4"
-            = selected_pills(@top_10_causes.map(&:name), "causes").join(', ')
-        = render SelectMultiple::Component.new(name: 'search[causes]', items: causes, selected: selected_advanced_filters(@top_10_causes.map(&:name), "causes"))
+            = selected_("pills", @top_10_causes, search.causes || []).join(', ')
+        = render SelectMultiple::Component.new(name: 'search[causes]', items: causes, selected: selected_("advanced_filters", @top_10_causes, search.causes || []))
 
       div class="px-6 py-8"
         = form.label :services, 'Services', class: 'w-full text-base font-bold text-gray-2'
-        - if search.services
+        - if selected_("pills", @top_10_services, search.services || []).any?
           div class='flex items-center gap-1'
             span class="relative inline-flex w-2 h-2 rounded-full bg-green-300"
             p class="text-sm text-gray-4" Selected Pills:
           p class="flex flex-wrap items-center gap-1 text-sm text-gray-4"
-            = selected_pills(@top_10_services.map(&:name), "services").join(', ')
-        = render SelectMultiple::Component.new(name: 'search[services]', items: services, selected: selected_advanced_filters(@top_10_services.map(&:name), "services"))
+            = selected_pills(@top_10_services, search.services || []).join(', ')
+        = render SelectMultiple::Component.new(name: 'search[services]', items: services, selected: selected_("advanced_filters", @top_10_services, search.services || []))
 
       div class="px-6 py-8"
         = form.label :beneficiary_groups, 'Populations Served', class: 'w-full text-base font-bold text-gray-2'
-        - if search.beneficiary_groups
+        - if selected_("pills", @top_10_beneficiary_subcategories, search.beneficiary_groups || []).any?
           div class='flex items-center gap-1'
             span class="relative inline-flex w-2 h-2 rounded-full bg-green-300"
             p class="text-sm text-gray-4" Selected Pills:
           p class="flex flex-wrap items-center gap-1 text-sm text-gray-4"
-            = selected_pills(@top_10_beneficiary_subcategories.map(&:name) , "beneficiary_groups").join(', ')
-        = render SelectMultiple::Component.new(name: 'search[beneficiary_groups]',items: beneficiary_groups, selected: selected_advanced_filters(@top_10_beneficiary_subcategories.map(&:name), "beneficiary_groups"))
+            = selected_pills(@top_10_beneficiary_subcategories, search.beneficiary_groups || []).join(', ')
+        = render SelectMultiple::Component.new(name: 'search[beneficiary_groups]',items: beneficiary_groups, selected: selected_("advanced_filters", @top_10_beneficiary_subcategories.map, search.beneficiary_groups || []))
 
     div class="flex flex-row justify-between w-full px-6 py-5 border-t border-gray-8"
       // For anchor and button tags stimulus uses the click event as default


### PR DESCRIPTION
### Context
When selecting pills and then removing them, the label Selected Pills in modal was still appearing causing confusion to user.

### What changed
Searches_helper method was refactored and the guard clause was made more secure now.

### How to test it

1. hivemind
2. select multiple pills
3. select advanced filters
4. clear pills
5. open modal and you should not see the selected label 

### References

[Notion ticket](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=0747bfd730a1430d837efc6ff0d9f6f4&pm=s)
