### PR TITLE
style<footer> (Terms and Conditions) --> (Terms of Use)

### DIFF
--- a/app/components/footer/component.html.slim
+++ b/app/components/footer/component.html.slim
@@ -11,7 +11,7 @@ footer class="bg-blue-dark"
         ul class="flex flex-col pb-5 md:pb-3 md:mr-10"
           li = link_to 'Help', faqs_path, class:"text-sm md:text-small"
           li = link_to 'Privacy Policy', privacy_policy_path, class:"text-sm md:text-small"
-          li = link_to 'Terms and Conditions', terms_of_use_path, class:"text-sm md:text-small"
+          li = link_to 'Terms of Use', terms_of_use_path, class:"text-sm md:text-small"
       div class="flex flex-col"
         div class="flex items-center pb-2 text-small"
           | Made with


### PR DESCRIPTION
### Context

There was discrepanacy in the copy Terms of Use, all over the app it is Terms of Use.
Despite this, the footer says Terms and Conditions.

### What changed

[style<footer> (Terms and Conditions) --> (Terms of Use)](https://github.com/TelosLabs/giving-connection/commit/5d97950675bcb47ed10a64a9f024d3c91981c939)

### How to test it

1. yarn install
2. hivemind
3. check footer label (Terms of Use)

### References

[Notion ticket](https://www.notion.so/668500b1d20944abb2fec3df69cfcb96?v=4f86b54e86e64ac9a92881430281e753&p=19bb0c937de448f0ab857c76e3a88910&pm=s)
