### PR TITLE
Hotfic | Recaptcha issue on contact form

### DIFF
--- a/app/views/messages/new.html.slim
+++ b/app/views/messages/new.html.slim
@@ -75,6 +75,6 @@
         = f.label :content, "*Message"
         = f.text_area :content, class:"c-input h-40", data: { 'contact-form-target': 'message'}
       div class="w-full"
-        = recaptcha_tags
+        = recaptcha_tags noscript: false
       div class="mt-3"
         = f.submit "Send message", class:"c-button"


### PR DESCRIPTION
### Context
Recaptcha on contact us page was failing (even though it was passed successfully) . After a hard refresh it was working properly.
### What changed
`recaptcha_tags(noscript: false)`
### How to test it
Fill in the form on the _contact us_ page.
### References
[Notion ticket](https://www.notion.so/High-Priority-Add-a-nonprofit-form-submission-error-423efdba1c944e20989330c7a5cf346f?d=5f3ba358c613448eabdb428640bff9c1)
