### PR TITLE
Hotfix | Create new org bug

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -99,14 +99,14 @@ module Admin
     end
 
     def resource_params
-      permit = dashboard.permitted_attributes << { social_media_attributes: %i[facebook instagram twitter linkedin
-                                                                               youtube blog id],
+      permit = dashboard.permitted_attributes << { social_media_attributes: %i[facebook instagram twitter linkedin youtube blog id],
                                                    service_attributes: %i[name description id],
                                                    beneficiary_subcategories_id: [],
                                                    services_id: [],
                                                    location_attributes: %i[address latitude longitude website main physical offer_services appointment_only],
                                                    tags_attributes: [],
-                                                   office_hours_attributes: %i[day open_time close_time closed] }
+                                                   office_hours_attributes: %i[day open_time close_time closed],
+                                                   organization_causes_attributes: %i[cause_id] }
       params.require(resource_class.model_name.param_key)
             .permit(permit)
             .transform_values { |value| value == '' ? nil : value }

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -45,7 +45,7 @@ class Organization < ApplicationRecord
   belongs_to :creator, polymorphic: true
 
   validates :name, presence: true, uniqueness: true
-  validates :causes, presence: true
+  validates :organization_causes, presence: true
   validates :ein_number, presence: true, uniqueness: true
   validates :irs_ntee_code, presence: true, inclusion: { in: Organizations::Constants::NTEE_CODE }
   validates :mission_statement_en, presence: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,7 +41,7 @@ unless Rails.env.production?
   # Population served categories and subcategories
   Rake::Task['populate:seed_beneficiaries_and_beneficiaries_subcategories'].invoke
 
-  # Pupulate organizations and locations
+  # Populate organizations and locations
   SpreadsheetParse.new.import("./lib/assets/GC_Dummy_Data_for_DB.xlsx")
 
 end


### PR DESCRIPTION
### Context
Admis were unable to create a new nonprofit on the admin panel.
### What changed
* Validation of `organization_causes` instead of `causes` association in `Organization` model.
* Addition of `organization_cause` parameter to strong `params` in `AdminOrganizations` controller.
### How to test it

### References

[Notion ticket](https://www.notion.so/High-Priority-Unable-to-create-new-organizations-6651abbd7ed84f6f92c768643b8d8b80)
