### PR TITLE
Feature/assign admin to org

### DIFF
--- a/lib/tasks/organization.rake
+++ b/lib/tasks/organization.rake
@@ -48,7 +48,7 @@ namespace :organization do
       )
       Rails.logger.info "User #{admin.email}-#{admin.id} succesfully assigned to Organization #{organization.name}-#{organization.id}"
     rescue => ex
-      Rails.logger.info "#{ex} for Organization: #{org_admin[:admin_email]}"
+      Rails.logger.info "#{ex} for Organization: #{org_admin[:org_name]}"
     end
   end
 end


### PR DESCRIPTION
### Context
The customer is not able to assign admins to organizations.

### What changed
Add rake task to create manually the association Organization-Admin.

### How to test it

### References

[Notion ticket](https://www.notion.so/Admin-Panel-Admin-Users-b7ed19bbff7c479f94b249d7a64439d6)
