### PR TITLE
Hotfix | Add alphabetical order to users

### DIFF
--- a/app/dashboards/organization_admin_dashboard.rb
+++ b/app/dashboards/organization_admin_dashboard.rb
@@ -11,7 +11,7 @@ class OrganizationAdminDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     organization: Field::BelongsTo,
-    user: Field::BelongsTo,
+    user: Field::BelongsTo.with_options(order: 'email'),
     id: Field::Number,
     role: Field::SelectBasic.with_options({
                                             choices: ['admin']


### PR DESCRIPTION
### Context


### What changed
Add alphabetical order to the user field on the OrganizationAdmin creation form in the admin panel.

### How to test it

### References

[Notion ticket](https://www.notion.so/Admin-Panel-Admin-Users-b7ed19bbff7c479f94b249d7a64439d6)
