### PR TITLE
Hotfix |  Users are unable to update organizations

### DIFF
--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -273,7 +273,7 @@ div class="w-full h-full bg-grey-9"
                         a href="mailto:admin@givingconnection.org"
                           |  admin@givingconnection.org
                         |  if you would like to add a service not currently found in the list below.
-                      = render SelectMultiple::Component.new(f: location_form, klass: "Service", items: @services, selected: location_form.object.location_services.map{ |location_service| location_service.service.name }, placeholder: "Write services", required: true)
+                      = render SelectMultiple::Component.new(f: location_form, klass: "Service", items: @services, selected: location_form.object.location_services.map{ |location_service| location_service.service.name }, placeholder: "Write services")
 
                   div[data-controller="modal" data-modal-allow-background-close="false"]
                     button type="button" class="flex justify-center px-6 py-3 mx-auto text-base font-medium hover:text-blue-medium text-gray-3" data-action="modal#open modal#readCheckboxesState"


### PR DESCRIPTION
### Context

Users are unable to update some organizations. 

The organization edit form cannot be submitted because services input is required, this error is flagged by the app but it is not visible to users because by checking "Yes" on "Do you offer any services at this address?" the field of services disappears.

### What changed

Remove `required: true` in the services input.  

### How to test it

### References

[Notion ticket](https://www.notion.so/Broken-Nonprofit-URL-on-pin-popup-4232802644964c81a935d635fa8d03c6)
