### PR TITLE
Decorated URL and prompt improvements

### DIFF
--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -98,8 +98,8 @@
                   p class="text-xs text-gray-4" id="pointer"
                     = link_to result.address, result.link_to_google_maps, target: "blank"
                   p class="text-xs text-blue-medium"
-                    = link_to result.organization.website, "http://#{result.organization.website}", target: "_blank"
-                  - if device == "mobile"
+                    = link_to result.organization.decorate.website, result.organization.decorate.website, target: "_blank"
+                  - if device == "mobile" && result.phone_number
                     a.text-xs.text-blue-medium[href="tel:#{result.phone_number&.number}"]
                       = "call: #{result.phone_number&.number}"
                   - else
@@ -147,7 +147,7 @@
                 p class="text-xs text-gray-4" id="pointer"
                   = link_to result.formatted_address, result.link_to_google_maps, target: "blank"
                 p class="text-xs text-blue-medium"
-                  = link_to "#{result.organization.website}", "http://#{result.organization.website}", target: "_blank"
+                  = link_to result.organization.decorate.website, result.organization.decorate.website, target: "_blank"
                 p class="text-xs text-gray-4"
                   | #{result.phone_number&.number}
                 p class="text-xs font-medium text-gray-2"


### PR DESCRIPTION
### Context
Small pop-ups on the map had wrong hrefs.
### What changed
Hrefs were decorated.
### How to test it
1. Go to `http://localhost:5000/search`
2. Click on a result card's title
3. Click on the link in the small pop-up
### References
[Notion ticket](https://www.notion.so/Broken-Nonprofit-URL-on-pin-popup-4232802644964c81a935d635fa8d03c6)
