### PR TITLE
organization_causes_attributes removed from resource_params

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -106,8 +106,7 @@ module Admin
                                                    services_id: [],
                                                    location_attributes: %i[address latitude longitude website main physical offer_services appointment_only],
                                                    tags_attributes: [],
-                                                   office_hours_attributes: %i[day open_time close_time closed],
-                                                   organization_causes_attributes: %i[cause_id] }
+                                                   office_hours_attributes: %i[day open_time close_time closed] }
       params.require(resource_class.model_name.param_key)
             .permit(permit)
             .transform_values { |value| value == '' ? nil : value }


### PR DESCRIPTION
### Context
Organization causes were being duplicated each time admins updated orgs.
### What changed
`organization_causes_attributes` were removed from `resource_params` in `admin/organizations_controller.rb`
### How to test it
1. Go to `http://localhost:5000/admin/organizations`
2. Update and org
### References
[Notion ticket](https://www.notion.so/High-Priority-Multiple-duplicates-causes-showing-in-left-side-panel-6ada7d997412457d9ff31b61a18dbc2a)
