### PR TITLE
Dicovery copy updated and background svg position improved

### DIFF
--- a/app/views/causes/index.html.slim
+++ b/app/views/causes/index.html.slim
@@ -21,10 +21,11 @@ div class="px-6"
       h2 class="mb-6 font-bold text-2xl"
         | Shine a light on good
       p class="max-w-sm"
-        | Use our discovery feature to find nonprofits serving your community.
-        | Select a cause below to learn more about organizations in the Nashville area providing critical services within your chosen category. 
-        | Scroll through listings to browse for nonprofits meeting your needs.
-      = inline_svg_tag "blur-background-3.svg", class: "absolute top-0 right-1/2 -z-1 w-80 transform translate-x-1/2"
+        | Use our browse by cause feature to find nonprofits serving your community. 
+        | Select a cause below to learn more about organizations in the Nashville area providing 
+        | critical services within your chosen category. Scroll through listings to discover 
+        | nonprofits meeting your needs.
+      = inline_svg_tag "blur-background-1", class: "absolute top-0 -z-1 w-full max-w-md md:-top-1/2"
     = inline_svg_tag "browse-by-causes.svg", class: "w-full max-w-md -mt-6 md:w-2/5"
 
   section class="flex flex-col items-center pt-6 mb-28 md:pt-28 md:mb-44" id="causes-section"


### PR DESCRIPTION
### Context
Discover page copy had a typo and the svg decoration of it was kind of cropped.
### What changed
* Discover page description updated
* SVG decoration improved
### How to test it
1. Go to `http://localhost:5000/discover`
### References
[Notion ticket](https://www.notion.so/High-Priority-Add-a-space-in-the-copy-on-the-Discover-tab-4086138045eb49448129db7fd4c9e3af)
___
![image](https://user-images.githubusercontent.com/62576509/227368998-c67710b0-b0da-4a6a-977a-6fff39803db8.png)

