### PR TITLE
Hotfix || Rollbar error #5 comparison of Time with nil failed

### DIFF
--- a/app/decorators/location_decorator.rb
+++ b/app/decorators/location_decorator.rb
@@ -27,11 +27,11 @@ class LocationDecorator < ApplicationDecorator
   end
 
   def open_time_for_display
-    object.office_hours.find_by(day: Time::DAYS_INTO_WEEK[:monday]).formatted_open_time&.strftime("%l:%M %p")
+    object.office_hours.find_by(day: Time::DAYS_INTO_WEEK[:monday])&.formatted_open_time&.strftime("%l:%M %p")
   end
 
   def close_time_for_display
-    object.office_hours.find_by(day: Time::DAYS_INTO_WEEK[:monday]).formatted_close_time&.strftime("%l:%M %p")
+    object.office_hours.find_by(day: Time::DAYS_INTO_WEEK[:monday])&.formatted_close_time&.strftime("%l:%M %p")
   end
 
   def street

--- a/app/models/locations/officeable.rb
+++ b/app/models/locations/officeable.rb
@@ -13,8 +13,9 @@ module Locations
     end
 
     def next_open_office_hours
-      return nil if office_hours.all? { |oh| oh.closed? }
+      return nil if office_hours.all? { |oh| oh.closed? } || today_office_hours.blank?
       return today_office_hours if !today_office_hours&.closed? && (Time.now < today_office_hours&.formatted_open_time)
+
       @next = today_office_hours&.next_office_hours
       loop do
         break unless @next.closed?


### PR DESCRIPTION
### Context

Rollbar # 5 showing `comparison of Time with nil failed` when a Location is created without one or more days of the week.

### What changed
Add a guard and self-navigator if one day of the week is missing.

### How to test it

### References

[Notion ticket](url)
