### PR TITLE
Hotfix | Location Card Title

### DIFF
--- a/app/components/result_card/component.html.erb
+++ b/app/components/result_card/component.html.erb
@@ -8,10 +8,10 @@
         <%# Org name %>
         <div>
           <%= link_to(
-            new_map_popup_path(location_id: @id), 
+            @turbo_frame[:src] || "javascript:void(0)", 
             class: "text-base font-bold text-black cursor-pointer",
             id: "new_favorite_location_#{@id}",
-            data: {turbo_frame: "map-left-popup"}
+            data: {turbo_frame: @turbo_frame[:id]}
           ) do %>
             <%= @title %>
           <% end %>

--- a/app/components/result_card/component.rb
+++ b/app/components/result_card/component.rb
@@ -2,7 +2,7 @@
 class ResultCard::Component < ViewComponent::Base
   include ApplicationHelper
 
-  def initialize(title:, address:, image_url:, website:, description:, id:, current_user:, phone_number:, verified:, causes: [])
+  def initialize(title:, address:, image_url:, website:, description:, id:, current_user:, phone_number:, verified:, causes: [], turbo_frame: {})
     @title = title
     @address = address
     @image_url = image_url
@@ -13,6 +13,8 @@ class ResultCard::Component < ViewComponent::Base
     @phone_number = phone_number
     @verified = verified
     @causes = causes
+    # If not targeting a turbo-frame, don't provide this parameter
+    @turbo_frame = turbo_frame
   end
 
   def formated_description

--- a/app/views/searches/show.html.slim
+++ b/app/views/searches/show.html.slim
@@ -57,7 +57,8 @@
                                                         phone_number: result.phone_number&.number, \
                                                         current_user: current_user, \
                                                         verified: result.organization.verified?, \
-                                                        causes: result&.causes)
+                                                        causes: result&.causes, \
+                                                        turbo_frame: {id: "map-left-popup", src: new_map_popup_path(location_id: result&.id)})
                   - if @pagy.pages > SearchesHelper::MIN_REQUIRED_PAGES
                     div class="h-40 px-4 mt-7"
                       p class="mb-5 text-sm text-gray-3"


### PR DESCRIPTION
### Context
The `map-left-popup` turbo-frame content was displayed when clicking on the location's name in the _Saved Pages_ tab of the user's account.
### What changed
The `ResultCard::Component` now accepts a parameter with all the `turbo-frame`'s information, so it will target it when you specify so.
### How to test it
### References
[Notion ticket](https://www.notion.so/High-Priority-Left-Popup-being-displayed-in-user-s-account-1841a2dcd3df4c3c859078076a54dd15)
