### PR TITLE
Turbo cache disabled in search view.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,11 @@
   <head>
     <title>Giving Connection</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    <% if request.fullpath.include? "/search" %>
+      <meta name="turbo-cache-control" content="no-preview">
+    <% end %>
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
### Context
Google map was rendering twice in `https://localhost:5000/search` due to Turbo Caching.
### What changed
Meta tag `<meta name="turbo-cache-control" content="no-preview">` added to the `<head>` element when users visit the aforementioned page.
### How to test it
Go to `https://localhost:5000/search`, then visit another tab and go back. You shouldn't see a cached preview.
### References
[Notion ticket](https://www.notion.so/High-Priority-Performance-Improvements-Turbo-cache-on-the-search-page-0a28a63ed7a84f499ab809df178441b4)
