### PR TITLE
Download nonprofits list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "invisible_captcha"
 
 gem 'active_storage_validations'
 gem 'aws-sdk-s3', require: false
+gem "caxlsx"
 gem 'clockwork'
 gem 'cocoon'
 gem 'draper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    caxlsx (3.4.1)
+      htmlentities (~> 4.3, >= 4.3.4)
+      marcel (~> 1.0)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
     childprocess (4.1.0)
     city-state (0.1.0)
       rubyzip (>= 1.1)
@@ -234,6 +239,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    htmlentities (4.3.4)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -571,6 +577,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 3.26)
+  caxlsx
   city-state
   clockwork
   cocoon

--- a/app/controllers/admin/export_locations_controller.rb
+++ b/app/controllers/admin/export_locations_controller.rb
@@ -1,0 +1,15 @@
+module Admin
+  class ExportLocationsController < Admin::ApplicationController
+    def new
+      locations = Location.order :name
+      file_path = LocationsExporter.call(locations, location_url(":id"))
+
+      send_file(
+        file_path,
+        filename: 'nonprofits-data.xlsx',
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        disposition: "attachment"
+      )
+    end
+  end
+end

--- a/app/services/locations_exporter.rb
+++ b/app/services/locations_exporter.rb
@@ -1,0 +1,33 @@
+class LocationsExporter < ApplicationService
+
+  def initialize(locations, link_pattern)
+    @locations = locations
+    @link_pattern = link_pattern
+  end
+
+  def call
+    package = Axlsx::Package.new
+    workbook = package.workbook
+
+    workbook.add_worksheet(name: "Giving Connection Nonprofits") do |sheet|
+      title_style = sheet.styles.add_style(bg_color: "FF0782D0", fg_color: "FFFFFFFF")
+      sheet.add_row ["Name", "GC profile link"], style: title_style
+
+      @locations.each do |location|
+        sheet.add_row [location.name, format_link(location.id)]
+      end
+    end
+
+    file_path = Rails.root.join('tmp', 'nonprofits-data.xlsx')
+    package.serialize(file_path)
+
+    file_path
+  end
+
+  private
+
+  def format_link(id)
+    location_id = id.to_s
+    @link_pattern.gsub(":id", location_id)
+  end
+end

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -51,6 +51,8 @@ It renders the `_table` partial to display details about the resources.
       [:new, namespace, page.resource_path.to_sym],
       class: "button",
     ) if valid_action?(:new) && show_action?(:new, new_resource) %>
+
+    <%= link_to 'Download list', new_admin_export_locations_path, class: 'button' %>
   </div>
 </header>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
         post :import
       end
     end
+    resource :export_locations, only: :new
   end
 
   devise_for :admin_users


### PR DESCRIPTION
### Context
The customer needed a way to download a list of nonprofit names along with their Giving Connection Profiles.
### What changed
* New `ExportLocationsController` controller
* New `LocationsExporter` service class
* "Download list" button on **Organizations** tab in admin panel
* `Axlsx` gem installed
### How to test it
1. Go to `http://localhost:5000/admin/organizations`
2. Click on "Download list"
### References
[Notion ticket](https://www.notion.so/Download-list-button-in-admin-panel-7fe843ecaf604866b879f6675aa8040b)
