### PR TITLE
Convert office hours to timezone

### DIFF
--- a/app/queries/locations/filter_query.rb
+++ b/app/queries/locations/filter_query.rb
@@ -118,7 +118,7 @@ module Locations
         return scope if open_now.nil?
 
         scope.joins(:office_hours).where(office_hours: {
-          day: Time.now.wday,
+          day: Time.zone.now.wday,
           closed: false,
         }).where(
           "? BETWEEN timezone('CST', open_time) AND timezone('CST', close_time)", Time.zone.now


### PR DESCRIPTION
### Context
The "Open now" search query was not working properly.
Times are stored in UTC by default, but displayed in the set timezone. This led to weird behavior like having a displayed `close_time` at 10PM CST that was actually 4 AM UTC (of the next day) in the database.

### What changed
Introduce timezone in the query so time ranges are calculated correctly. 

### How to test it

### References

[ClikUp ticket](https://app.clickup.com/t/85yx52u1u)
