### PR TITLE
Hotfix | Disable turbo on contact us form

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
       <meta name="turbo-cache-control" content="no-preview">
     <% end %>
 
+    <%= yield(:head) %>
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/messages/new.html.slim
+++ b/app/views/messages/new.html.slim
@@ -1,3 +1,7 @@
+// Recaptcha needs full reload to work properly
+= content_for :head do
+  meta name="turbo-visit-control" content="reload"
+
 .main.flex.flex-col.items-center
   - if current_page?(non_profit_contact_path) || @form_to_render == "add_nonprofit"
     h2 class="pb-4 text-2xl font-bold text-center pt-6 md:pt-16 md:mt-2 md:pb-9 text-gray-3"
@@ -77,6 +81,6 @@
       // Honeypot
       = invisible_captcha :street, :message
       div class="w-full"
-        = recaptcha_tags noscript: false
+        = recaptcha_tags
       div class="mt-3"
         = f.submit "Send message", class:"c-button"


### PR DESCRIPTION
### Context
Bots are sending hundreds of emails through the "Contact Us" form.

### What changed
Disable turbo on the "Contact Us" view because Recaptcha needs a full reload to work properly

### References

[Click Up](https://app.clickup.com/t/85yx52u13)
