### PR TITLE
Feature | Fix layout in organization form

### DIFF
--- a/app/views/organizations/_location_fields.html.slim
+++ b/app/views/organizations/_location_fields.html.slim
@@ -1,9 +1,9 @@
 div class="grid grid-cols-12 gap-6 mt-8 nested-fields" data-action="google-maps-callback@window->places#initMap" data-controller="places toggle" data-places-imageurl-value=("\#{asset_path 'markergc.png'}")
   div class="col-span-12 lg:col-span-6 md:col-span-7"
     = location_form.label :name, "Location Name", class:"text-sm"
-    = location_form.text_field :name, class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium"
-    = location_form.label :address, "Address", class: "block mt-4 text-sm text-gray-3 font-medium"
-    = location_form.search_field :address, class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium", data: { 'places-target': "field", action: "keydown->places#keydown" }
+    = location_form.text_field :name, class: "block mb-4 h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium"
+    = location_form.label :address, "Address", class: "block text-sm text-gray-3 font-medium"
+    = location_form.search_field :address, class: "block mb-4 h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium", data: { 'places-target': "field", action: "keydown->places#keydown" }
     = location_form.label :suite, "Suite Number", class:"text-sm"
     = location_form.text_field :suite, class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium"
     = location_form.hidden_field :latitude, data: { 'places-target': "latitude" }, id: "places-latitude"
@@ -12,43 +12,38 @@ div class="grid grid-cols-12 gap-6 mt-8 nested-fields" data-action="google-maps-
     div class="mt-6"
       div data-places-target="map" style="height:400px;"class="w-full h-full"
 
-  div class="hidden col-span-3 md:flex"
+  div class="hidden md:block md:col-span-5"
 
-  div class="hidden col-span-3 md:flex"
-
-  div class="col-span-12 lg:col-span-6 md:col-span-7"
-    div class="flex items-center mt-3"
+  div class="col-span-12 md:col-span-7 lg:col-span-6"
+    div class="flex items-center"
       = location_form.check_box :physical, class: " h-4 w-4 mt-1 mr-2 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent "
       = location_form.label :physical, "This is also my physical address", class: "text-sm text-black "
 
-  div class="hidden col-span-3 md:flex"
+  div class="hidden md:block md:col-span-5"
 
-  div class="col-span-12 mt-6 mb-4 lg:col-span-6 md:col-span-7"
+  div class="col-span-12 md:col-span-7 lg:col-span-6"
     = location_form.fields_for :phone_number, PhoneNumber.new do |phone_form|
       = phone_form.label :number, "Phone", class: "block text-sm text-gray-3 font-medium"
-      = phone_form.text_field :number, { class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }
-
-  div class="hidden col-span-3 md:flex"
-    = location_form.label :email, "Email", class:"block text-sm text-gray-3 font-medium pt-4"
-    = location_form.text_field :email, class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium"
-
-  div class="hidden col-span-3 md:flex"
-    = location_form.label :youtube_video_link, "YouTube Video Link", class:"block text-sm text-gray-3 font-medium pt-4"
+      = phone_form.text_field :number, { class: "block mb-4 h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }
+    = location_form.label :email, "Email", class:"block text-sm text-gray-3 font-medium"
+    = location_form.text_field :email, class: "block mb-4 h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium"
+    = location_form.label :youtube_video_link, "YouTube Video Link", class:"block text-sm text-gray-3 font-medium"
     = location_form.text_field :youtube_video_link, class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium"
 
-  div class="hidden col-span-3 md:flex"
-  div class="col-span-12 lg:col-span-6 md:col-span-7"
-    fieldset class='mt-4'
-      p class="text-sm font-medium leading-4 text-gray-2"
-        | Do you offer any services at this address?
-      legend.sr-only Alert frequency
-      div class='flex items-center gap-12 mt-3'
-        div class="flex items-center gap-2"
-          = location_form.radio_button :offer_services, 1, class: "focus:ring-0 focus:ring-transparent", data: { action: "toggle#show" }
-          = location_form.label :offer_services_yes, "Yes", class: "text-sm text-black "
-        div class="flex items-center gap-2"
-          = location_form.radio_button :offer_services, 0, class: "focus:ring-0 focus:ring-transparent", data: { action: "toggle#toggle"}, checked: true
-          = location_form.label :offer_services_no, "No", class: "text-sm text-black "
+  div class="hidden md:block md:col-span-5"
+
+  fieldset class="col-span-12 md:col-span-7 lg:col-span-6"
+    p class="text-sm font-medium leading-4 text-gray-2"
+      | Do you offer any services at this address?
+    legend.sr-only Alert frequency
+    div class='flex items-center gap-12 mt-3'
+      div class="flex items-center gap-2"
+        = location_form.radio_button :offer_services, 1, class: "focus:ring-0 focus:ring-transparent", data: { action: "toggle#show" }
+        = location_form.label :offer_services_yes, "Yes", class: "text-sm text-black "
+      div class="flex items-center gap-2"
+        = location_form.radio_button :offer_services, 0, class: "focus:ring-0 focus:ring-transparent", data: { action: "toggle#toggle"}, checked: true
+        = location_form.label :offer_services_no, "No", class: "text-sm text-black "
+
   div class="col-span-12 px-3.5 py-5 bg-gray-9"
     p class="text-sm leading-5 text-gray-3"
       ' If you choose
@@ -56,7 +51,7 @@ div class="grid grid-cols-12 gap-6 mt-8 nested-fields" data-action="google-maps-
         | yes
       |, this location will be displayed on the search listings as a pin on the map.
 
-  div class="hidden col-span-12 lg:col-span-6 md:col-span-7" data-toggle-target="toggleable menu"
+  div class="hidden col-span-12 md:col-span-7 lg:col-span-6 " data-toggle-target="toggleable menu"
     div class='mt-3' data-controller="services" data-services-options-value=@services
       div class="col-span-12 lg:col-span-6 md:col-span-7"
         = label_tag "", "Services offered on this location", class:"text-sm font-medium leading-4 text-gray-2"
@@ -104,7 +99,9 @@ div class="grid grid-cols-12 gap-6 mt-8 nested-fields" data-action="google-maps-
       div class="flex items-center mt-3"
         = location_form.check_box :appointment_only, class: " h-4 w-4 mt-1 mr-2 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent "
         = location_form.label :appointment_only, "By Appointment Only", class: "text-sm text-black"
+
   div class="hidden col-span-3 md:flex"
+
   div class="col-span-12 text-center lg:col-span-6 md:col-span-7"
     = link_to 'Remove Location', "#", data: { action: "click->nested-form#remove_association" }, class:"text-sm font-bold cursor-pointer text-blue-medium"
     = location_form.hidden_field :_destroy

--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -76,6 +76,8 @@ div class="w-full h-full bg-grey-9"
             = f.label :website, class: "block text-sm text-gray-3 font-medium"
             = f.text_field :website, { class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }
 
+          div class="hidden col-span-3 md:flex"
+
           div class="col-span-12 lg:col-span-7 md:col-span-6"
             = f.label :donation_link, class: "block text-sm text-gray-3 font-medium"
             = f.text_field :donation_link, { class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }


### PR DESCRIPTION
### Context
Validation errors for `OfficeHours` seems not working in the edit organization form (My nonprofit pages). Also, the layout is broken.

### What changed
It seems that validation errors work as expected so just fix the layout.

### How to test it
1. Go to `My Account`
2. Click on `My nonprofit pages`
3. Click on `edit`
4. Try to add a location without office hours by clicking on the `ADD MORE LOCATIONS` button
5. Validations should be displayed at the top of the page

### References
[ClickUp](https://app.clickup.com/t/85yx52u28)

### Validation errors
https://github.com/TelosLabs/giving-connection/assets/63365501/3d7b6e55-213a-4519-a524-8d5102f7ed28

### Layout
https://github.com/TelosLabs/giving-connection/assets/63365501/98ee67e1-7f3a-4195-bb74-a606c48a6fdb


