### PR TITLE
Feature | Add services section on the admin panel

### DIFF
--- a/app/dashboards/service_dashboard.rb
+++ b/app/dashboards/service_dashboard.rb
@@ -10,11 +10,13 @@ class ServiceDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
+    cause: Field::BelongsTo,
+    location_services: Field::HasMany,
+    locations: Field::HasMany,
     id: Field::Number,
     name: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    cause: Field::BelongsTo
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -31,6 +33,7 @@ class ServiceDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
     name
+    cause
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -38,6 +41,7 @@ class ServiceDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
     name
+    cause
   ].freeze
 
   # COLLECTION_FILTERS

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     resources :admin_users
     resources :users
     resources :social_medias, only: %i[new create edit update]
-    resources :services, only: %i[new create edit update]
+    resources :services, except: %i[destroy]
     resources :causes, only: %i[new create edit update]
     resources :categories, only: %i[new create edit update]
     resources :locations, except: %i[index]


### PR DESCRIPTION
### Context
The services section is missing in the admin panel

### What changed
It seems that the links in the navigation sidebar in the admin panel can be hidden by removing their index action from the routes, see [here](https://github.com/thoughtbot/administrate/issues/626#:~:text=you%20can%20remove%20resources%20form%20the%20sidebar%20by%20removing%20their%20index%20action%20from%20the%20routes.%20for%20example%3A).

### References
[ClickUp](https://app.clickup.com/t/85yx52u3c)

https://github.com/TelosLabs/giving-connection/assets/63365501/80a257d9-15d6-4866-b1fd-35233429f5da



