### PR TITLE
Feature | Popout When Click on Nonprofit Name

### DIFF
--- a/app/components/map_left_popup/component.html.slim
+++ b/app/components/map_left_popup/component.html.slim
@@ -3,7 +3,7 @@ div class="relative flex flex-col gap-2 p-7 bg-white rounded-6px" id="loc_#{@res
     = image_tag @result.organization.logo, class: "w-1/5 h-1/5 mt-1"
     div class="flex flex-col ml-2"
       div
-        = link_to location_path(@result), class: "font-semibold text-sm lg:text-base cursor-pointer" do
+        = link_to location_path(@result), class: "font-semibold text-sm lg:text-base cursor-pointer", target: "_blank" do
           = @result.organization.name
         - if @result.organization.verified?
           = inline_svg_tag 'verified_nonprofit_check.svg', class: 'w-4 h-4 ml-1 align-text-bottom inline'


### PR DESCRIPTION
### What changed
Now, when you click on a nonprofit name on the search page, it will open on a new tab. 
### How to test it
Click on a nonprofit name on the search page. 
### References
![Google Chrome - Giving Connection 2023-07-24 at 11 09 56 PM](https://github.com/TelosLabs/giving-connection/assets/119626526/2f6ffe98-8865-4d97-8217-7ea97fbef13c)

[[Notion ticket](url)
](https://app.clickup.com/t/85yx52u4h)