### PR TITLE
Search Engine Optimization and Prioritization

### DIFF
--- a/app/models/locations/searchable.rb
+++ b/app/models/locations/searchable.rb
@@ -21,11 +21,8 @@ module Locations
                         social_media: %i[facebook instagram twitter linkedin youtube blog]
                       },
                       using: {
-                        tsearch: { prefix: true, any_word: true, dictionary: 'english', normalization: 4 },
-                        dmetaphone: {},
-                        trigram: { threshold: 0.5, word_similarity: true }
-                      },
-                      ranked_by: ":tsearch + (0.75 * :trigram)"
+                        tsearch: { prefix: true, dictionary: 'english' }
+                      }
     end
   end
 end


### PR DESCRIPTION
### Context

We were getting unexpected behavior in the search, with partial word matches ranking higher than full matches. 
Example:
- when looking for "pets for veterans", an eating disorder organization appears in second place
- when looking for "24 hour pet vet", mental health orgs appear first. 

### What changed
- Added dictionary to allow matching variant words (e.g. disabled, disability)
- Remove "any word: true" option so when searching for 2 or more keywords, only orgs with all the words in their profile will appear. 
- Remove trigram search to prevent words like "disorder" to match when looking for "disabled"

### How to test it

Search for "pets for veterans", "24 hour pet vet" and other bug-prone search terms documented in the ticket. 

### References

[ClickUp ticket](https://app.clickup.com/t/85yx52u48)
