### PR TITLE
Feature | Making Map Address Clickable 

### DIFF
--- a/app/components/map_left_popup/component.html.slim
+++ b/app/components/map_left_popup/component.html.slim
@@ -7,8 +7,10 @@ div class="relative flex flex-col gap-2 p-7 bg-white rounded-6px" id="loc_#{@res
           = @result.organization.name
         - if @result.organization.verified?
           = inline_svg_tag 'verified_nonprofit_check.svg', class: 'w-4 h-4 ml-1 align-text-bottom inline'
-      h4 class="text-gray-500 lg:text-sm text-xs"
-        = @result.address
+          
+      p class="text-gray-500 lg:text-sm text-xs" id="pointer"
+        = link_to @result.address, @result.link_to_google_maps, target: "blank"
+
     button type="button" data-action="click->places#hidePopup" class="absolute top-3 right-3" aria-label="close"
       = inline_svg_tag "x-icon.svg", class: "w-3 h-3", aria_hidden: true
   div class=" pt-4 my-4 border-t border-gray-8"


### PR DESCRIPTION
### What changed
Now, a user can click on the address in the larger pop-out map 

### How to test it
Click on the address on the larger pop-out map, it should take you to a new tab with the link to the google maps of the organization. 

### References
![2023-07-26 at 9 25 06 AM](https://github.com/TelosLabs/giving-connection/assets/119626526/315219d0-9de0-41b0-8f7e-4303bdb26345)

[[ClickUp ticket](url)
](https://app.clickup.com/t/85yx52u5g)