### PR TITLE
Add weight to org name

### DIFF
--- a/app/models/locations/searchable.rb
+++ b/app/models/locations/searchable.rb
@@ -15,13 +15,13 @@ module Locations
                         causes: { name: 'B' },
                         services: { name: 'C' },
                         tags: { name: 'D' },
-                        organization: %i[name second_name scope_of_work website ein_number irs_ntee_code
-                                         mission_statement_en vision_statement_en tagline_en
-                                         mission_statement_es vision_statement_es tagline_es],
+                        organization: { name: 'A', second_name: nil, scope_of_work: nil, website: nil, ein_number: nil, irs_ntee_code: nil,
+                                        mission_statement_en: nil, vision_statement_en: nil, tagline_en: nil,
+                                        mission_statement_es: nil, vision_statement_es: nil, tagline_es: nil },
                         social_media: %i[facebook instagram twitter linkedin youtube blog]
                       },
                       using: {
-                        tsearch: { prefix: true, dictionary: 'english' }
+                        tsearch: { dictionary: 'english' }
                       }
     end
   end


### PR DESCRIPTION
### Context

Organization name had lower weight than other fields when ranking search results.

### What changed

Add weight "A" to organization name so now it has the same priority as Location name. 

### How to test it

Reproduce buggy search described in the ticket by Stephanie. 

### References

[ClickUp ticket](https://app.clickup.com/t/85yx52u48)
