### PR TITLE
Open profile page in  a new tab on mobile devices

### DIFF
--- a/app/components/result_card/component.html.erb
+++ b/app/components/result_card/component.html.erb
@@ -7,6 +7,9 @@
       <div class="flex flex-row items-start justify-between">
         <%# Org name %>
         <div>
+        <% if device == "mobile" %>
+          <%= link_to @title, location_path(@id), class: "text-base font-bold text-black cursor-pointer", target: "_blank"  %>
+        <% else %>
           <%= link_to(
             @turbo_frame[:src] || "javascript:void(0)",
             class: "text-base font-bold text-black cursor-pointer",
@@ -15,6 +18,7 @@
           ) do %>
             <%= @title %>
           <% end %>
+        <% end %>
           <% if @verified %>
             <%= inline_svg_tag 'verified_nonprofit_check.svg', class: 'w-4 h-4 ml-1 align-text-bottom inline' %>
           <% end %>


### PR DESCRIPTION
### Context

On desktop, clicking the name of the organization in the result list opens a pop-up window on top of the map.
On mobile, this action should open a new tab with the results page. This was broken. 

### What changed

Add a check for device so the link opens a new tab on mobile devices.

### How to test it
This behavior is based on the **user agent, not the screen size.** 
Thus, to test it:
#### In development:
Hardcode `device` method on `ApplicationHelper` to always return "mobile".
Video demo: 

https://github.com/TelosLabs/giving-connection/assets/67963195/f3f5de84-560e-4d58-ba3c-fcfd85c111df

#### In staging:
Test it in a mobile device.  

### References

[ClickUp ticket](https://app.clickup.com/t/85yx52u4c)
