### PR TITLE
Truncate long urls in results card

### DIFF
--- a/app/components/result_card/component.html.erb
+++ b/app/components/result_card/component.html.erb
@@ -40,7 +40,7 @@
           <p id="pointer"><%= link_to @address, @link_to_google_maps, target: "blank" %></p>
         <% end %>
         <% if @website.present? %>
-          <%= link_to @website, @website, target: '_blank', class: 'text-blue-medium'%>
+          <%= link_to @website_for_display, @website, target: '_blank', class: 'text-blue-medium'%>
         <% end %>
         <% if device == "mobile" && @phone_number.present? %>
         <a class="text-xs text-blue-medium" href="tel:<%= @phone_number %>">

--- a/app/components/result_card/component.rb
+++ b/app/components/result_card/component.rb
@@ -19,9 +19,16 @@ class ResultCard::Component < ApplicationViewComponent
     @causes = causes
     # If not targeting a turbo-frame, don't provide this parameter
     @turbo_frame = turbo_frame
+    @website_for_display = website_for_display
   end
 
   def formated_description
     @description.length <= 280 ? @description : "#{@description[0..280]} (...)"
+  end
+
+  def website_for_display
+    return @website if @website.length < 40
+
+    @website.truncate(40)
   end
 end


### PR DESCRIPTION
### Context

Long URLS were being cut off in the results card.

### What changed

Truncate displayed urls (not the href itself) when longer than 40 characters. 

### How to test it

Manually generate a long url in the local database from your console:
```
Location.find(9).update website: "https://www.secondharvestmidtn.org/this-is-a-very-long-website-address-and-it-shoud-be-truncated"
```

Go to search page and look for that result card. 

### References

[ClickUp ticket](https://app.clickup.com/t/85yx52u5a)
