### PR TITLE
Temporarily fix search engine

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -31,7 +31,7 @@ class Search
       lat: lat.presence&.to_f, lon: lon.presence&.to_f
     }
 
-    @results = Locations::FilterQuery.call(filters, Location.active)
-    @results = keyword.present? ? Locations::KeywordQuery.call({ keyword: keyword }, @results) : @results
+    @results = keyword.present? ? Locations::KeywordQuery.call({ keyword: keyword }) : Location.active
+    @results = Locations::FilterQuery.call(filters, @results)
   end
 end


### PR DESCRIPTION
### Context

Breaking changes were recently introduced in the search module. This change was aimed to adequately sort the results of the search query after recent fixes on the Open Now behavior. 
This PR temporarily fixes the error, with the drawback of giving non-sorted results. Further research is necessary to reenable an adequate sorting of the results (based on pg_search priority). 

### What changed

Revert changes in the search module. 

### How to test it

Go to search and select any search pill. 

### References

[ClickUp ticket](https://app.clickup.com/t/8678jkk9c)
[Rollbar error](https://app.rollbar.com/a/app248961609-heroku.com/fix/item/app248961609-heroku.com/115)

