### PR TITLE
Remove physical address option from locations

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -104,7 +104,7 @@ module Admin
                                                    service_attributes: %i[name description id],
                                                    beneficiary_subcategories_id: [],
                                                    services_id: [],
-                                                   location_attributes: %i[address latitude longitude website main physical offer_services appointment_only],
+                                                   location_attributes: %i[address latitude longitude website main offer_services appointment_only],
                                                    tags_attributes: [],
                                                    office_hours_attributes: %i[day open_time close_time closed] }
       params.require(resource_class.model_name.param_key)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -93,7 +93,7 @@ class OrganizationsController < ApplicationController
                   social_media_attributes: %i[facebook instagram twitter linkedin youtube blog id],
                   tags_attributes: [],
                   locations_attributes: [:id, :name, :address, :latitude, :longitude, :website, :po_box, :public_address, :youtube_video_link,
-                                         :main, :physical, :offer_services, :appointment_only, :email, :_destroy,
+                                         :main, :offer_services, :appointment_only, :email, :_destroy,
                                          { phone_number_attributes: [:number],
                                            office_hours_attributes: %i[id day open_time close_time closed],
                                            images: [],

--- a/app/dashboards/location_dashboard.rb
+++ b/app/dashboards/location_dashboard.rb
@@ -20,7 +20,6 @@ class LocationDashboard < Administrate::BaseDashboard
     lonlat: Field::String.with_options(searchable: false),
     email: Field::String,
     main: Field::Boolean,
-    physical: Field::Boolean,
     offer_services: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -63,7 +62,6 @@ class LocationDashboard < Administrate::BaseDashboard
     email
     main
     images
-    physical
     offer_services
     address
     suite
@@ -80,7 +78,6 @@ class LocationDashboard < Administrate::BaseDashboard
     main
     youtube_video_link
     images
-    physical
     appointment_only
     email
     phone_number

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -11,7 +11,6 @@
 #  lonlat           :geography        not null, point, 4326
 #  website          :string
 #  main             :boolean          default(FALSE), not null
-#  physical         :boolean
 #  offer_services   :boolean
 #  organization_id  :bigint
 #  created_at       :datetime         not null
@@ -50,7 +49,6 @@ class Location < ActiveRecord::Base
   validates :longitude, presence: true
   validates :lonlat, presence: true
   validates :main, inclusion: { in: [true, false] }
-  validates :physical, inclusion: { in: [true, false] }
   validates :offer_services, inclusion: { in: [ true, false ] }
   validates :appointment_only, inclusion: { in: [true, false] }
 

--- a/app/models/spreadsheet_parse.rb
+++ b/app/models/spreadsheet_parse.rb
@@ -150,7 +150,7 @@ class SpreadsheetParse
 
   def build_location_hash(location_row)
     { address: location_row['address'], website: location_row['website'],
-      main: location_row['main'] == 'yes', physical: location_row['physical'] == 'yes',
+      main: location_row['main'] == 'yes',
       appointment_only: location_row['appointment_only'] == 'yes',
       offer_services: location_row['offer_services'] == 'yes',
       name: location_row['name'],

--- a/app/views/organizations/_location_fields.html.slim
+++ b/app/views/organizations/_location_fields.html.slim
@@ -29,11 +29,6 @@ div class="grid grid-cols-12 gap-6 mt-8 nested-fields" data-action="google-maps-
 
   div class="hidden md:block md:col-span-5"
 
-  div class="col-span-12 md:col-span-7 lg:col-span-6"
-    div class="flex items-center"
-      = location_form.check_box :physical, class: " h-4 w-4 mt-1 mr-2 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent "
-      = location_form.label :physical, "This is also my physical address", class: "text-sm text-black "
-
   div class="hidden md:block md:col-span-5"
 
   div class="col-span-12 md:col-span-7 lg:col-span-6"

--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -224,10 +224,6 @@ div class="w-full h-full bg-grey-9"
                     div data-places-target="map" style="height:400px;"class="w-full h-full"
 
                 div class="hidden col-span-3 md:flex"
-                div class="col-span-12 lg:col-span-6 md:col-span-7"
-                  div class="flex items-center"
-                    = location_form.check_box :physical, class: "h-4 w-4 mt-1 mr-2 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent "
-                    = location_form.label :physical, "This is also my physical address", class: "text-sm text-black"
 
                 div class="hidden col-span-3 md:flex"
 

--- a/db/migrate/20230804232930_remove_physical_from_locations.rb
+++ b/db/migrate/20230804232930_remove_physical_from_locations.rb
@@ -1,0 +1,5 @@
+class RemovePhysicalFromLocations < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :locations, :physical
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_26_001911) do
+ActiveRecord::Schema.define(version: 2023_08_04_232930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -167,7 +167,6 @@ ActiveRecord::Schema.define(version: 2023_07_26_001911) do
     t.geography "lonlat", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}, null: false
     t.string "website"
     t.boolean "main", default: false, null: false
-    t.boolean "physical"
     t.boolean "offer_services"
     t.bigint "organization_id"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     longitude { 1.5 }
     lonlat { Geo.point(1.5, 1.5) }
     main { true }
-    physical { true }
     offer_services { true }
     appointment_only { true }
   end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Location, type: :model do
     it { should validate_presence_of(:latitude) }
     it { should validate_presence_of(:longitude) }
     it { should validate_inclusion_of(:main).in_array([true, false]) }
-    it { should validate_inclusion_of(:physical).in_array([true, false]) }
     it { should validate_inclusion_of(:offer_services).in_array([true, false]) }
     it { should validate_inclusion_of(:appointment_only).in_array([true, false]) }
   end


### PR DESCRIPTION
### Context

In the location form, PO box question and "this is my physical address" checkbox accomplish the same. 

### What changed
Remove physical address question. 

### How to test it

My Non Profit Pages -> Edit -> checkbox does no longer appears

### References

[ClickUp ticket](https://app.clickup.com/t/85yx52u66)
