### PR TITLE
Fix collection for keyword query

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -31,7 +31,7 @@ class Search
       lat: lat.presence&.to_f, lon: lon.presence&.to_f
     }
 
-    @results = keyword.present? ? Locations::KeywordQuery.call({ keyword: keyword }) : Location.active
-    @results = Locations::FilterQuery.call(filters, @results)
+    @results = Location.where(id: Locations::FilterQuery.call(filters, Location.active).pluck(:id))
+    @results = keyword.present? ? Locations::KeywordQuery.call({ keyword: keyword }, @results) : @results
   end
 end


### PR DESCRIPTION
### Context

[Switching the order of the filter and keyword search](https://github.com/TelosLabs/giving-connection/pull/444/commits/1cffe1d79fce053e9c44f8de75dbf9556b4c3508) broke the search engine in a way that prevented using both searches at the same time. 

When using the `search_by_keyword`  `pg_search_scope` in the filtered collection (this is, a collection of `Location` instances returned by the `FilterQuery` module), it did not work. 
 
### What changed

[This stackoverflow question](https://stackoverflow.com/questions/41785495/pg-search-scope-chaining-scopes-seems-impossible) suggested to re-write the collection using the `pluck` method before passing it to `pg_search`.

After this operation, the `pg_search_scope` worked. 


### How to test it

Use keyword and pill search at the same time. 

### References

[ClickUp ticket](https://app.clickup.com/t/865cwpxj9)
