### PR TITLE
Email alerts - Make name of nonprofit direct to GivingConnection profile

### DIFF
--- a/app/views/saved_search_alert_mailer/send_alert.html.erb
+++ b/app/views/saved_search_alert_mailer/send_alert.html.erb
@@ -14,7 +14,7 @@
         <%= link_to (image_tag(attachments[location.organization.logo.blob.filename.to_s].url, style: "max-width: 100%; height: 96px; object-fit: contain;")), location_url(location.id),  target: "_blank", style: "margin: 0px; text-decoration: none; color: inherit;" %>
       </div>
       <div style="margin: 0px; margin-left: 16px;">
-        <a href=<%= location.organization.decorate.website %> target="_blank" style="margin: 0px; text-decoration: none; color: inherit;"><h5 style="margin: 0px; font-size: 18px; font-weight: 700; color: #000000;"><%= location.name %></h5></a>
+        <a href=<%= location_url(location) %> target="_blank" style="margin: 0px; text-decoration: none; color: inherit;"><h5 style="margin: 0px; font-size: 18px; font-weight: 700; color: #000000;"><%= location.name %></h5></a>
         <div style="margin: 0px; margin-top: 5px; font-size: 12px; color: #9ca3af;">
           <%= link_to location.decorate.street, "https://www.google.com/maps/search/#{location.formatted_address}", target: "blank", style: "margin: 0px; text-decoration: none; color: inherit;" %>
           <%= link_to location.decorate.city_state_zipcode, "https://www.google.com/maps/search/#{location.formatted_address}", target: "blank", style: "margin: 0px; text-decoration: none; color: inherit;" %>


### PR DESCRIPTION
### Context

In email alert, clicking the name of an organization would take the user to the website of the non profit.

### What changed

Clicking on the name will take the user to GivingConnection non profit's profile. 

<img width="956" alt="image" src="https://github.com/TelosLabs/giving-connection/assets/67963195/0bebd37c-2a49-4e5f-9fae-267e6116c875">


### How to test it

Update the `SavedSearchAlertPreview` class with a user id of your local db. 
Create and send an alert email form the console: 

```
preview = SavedSearchAlertMailerPreview.new
mail = preview.send_alert
mail.deliver_now 
```

### References

[ClickUp ticket](https://app.clickup.com/t/85yx52u6k)
