### PR TITLE
Sort services and populations served by alphabetical order in org profile

### DIFF
--- a/app/views/locations/show.html.slim
+++ b/app/views/locations/show.html.slim
@@ -162,14 +162,14 @@ div class=""
       h3 class="text-sm font-bold uppercase mb-3.5"
         | Services Offered
       ul class="flex flex-col gap-8"
-        - @location.location_services.each do |location_service|
+        - @location.location_services.sort_by {|obj| obj.service.name }.each do |location_service|
           li class="text-sm font-base text-gray-2"
             = location_service.service.name
       div class="border-t border-gray-8 my-7"
       h3 class="text-sm font-bold uppercase mb-3.5"
         | Populations Served
       ul class="flex flex-col gap-8"
-        - @location.organization.beneficiary_subcategories.each do |pop_served|
+        - @location.organization.beneficiary_subcategories.sort_by { |obj| obj.name }.each do |pop_served|
           li class="text-sm font-base text-gray-2"
             = pop_served.name
       - if @location.social_media.present?


### PR DESCRIPTION
### Context

Services Offered and Populations Served are not in alphabetical order

### What changed

Sort collections in location show view.
![image](https://github.com/TelosLabs/giving-connection/assets/67963195/9566907e-338d-4a51-a2ed-a7b2336e5ee0)
![image](https://github.com/TelosLabs/giving-connection/assets/67963195/c0e66dbc-366a-416d-a0de-dd2451a966f7)


### How to test it

Go to any non profit profile. 

### References

[ClickUp ticket](https://app.clickup.com/t/85yx52u7z)
