### PR TITLE
Feature | Copy change

### DIFF
--- a/app/views/organizations/_location_fields.html.slim
+++ b/app/views/organizations/_location_fields.html.slim
@@ -111,7 +111,7 @@ div class="grid grid-cols-12 gap-6 mt-8 nested-fields" data-action="google-maps-
     div class="flex flex-col mt-3"
         div
           = location_form.radio_button :non_standard_office_hours, :always_open, class: " h-4 w-4 mt-1 mr-2 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent ", checked: location_form.object.always_open?
-          = location_form.label :non_standard_office_hours, "Always open", class: "text-sm text-black", value: :always_open
+          = location_form.label :non_standard_office_hours, "Always Open", class: "text-sm text-black", value: :always_open
         div
           = location_form.radio_button :non_standard_office_hours, :appointment_only, class: " h-4 w-4 mt-1 mr-2 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent ", checked: location_form.object.appointment_only?
           = location_form.label :non_standard_office_hours, "By Appointment Only", class: "text-sm text-black", value: :appointment_only

--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -350,7 +350,7 @@ div class="w-full h-full bg-grey-9"
                     div class="flex flex-col mt-3"
                       div
                         = location_form.radio_button :non_standard_office_hours, :always_open, class: " h-4 w-4 mt-1 mr-2 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent ", checked: location_form.object.always_open?
-                        = location_form.label :non_standard_office_hours, "Always open", class: "text-sm text-black", value: :always_open
+                        = location_form.label :non_standard_office_hours, "Always Open", class: "text-sm text-black", value: :always_open
                       div
                         = location_form.radio_button :non_standard_office_hours, :appointment_only, class: " h-4 w-4 mt-1 mr-2 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent ", checked: location_form.object.appointment_only?
                         = location_form.label :non_standard_office_hours, "By Appointment Only", class: "text-sm text-black", value: :appointment_only


### PR DESCRIPTION
### What changed
Change `Always open` to `Always Open` on the nonprofit edit page.

### How to test it
Go to a nonprofit edit page

### References
[ClickUp ticket](https://app.clickup.com/t/85yx52u5v)

####Before
![image](https://github.com/TelosLabs/giving-connection/assets/63365501/0b9a0b40-99ac-4bae-992e-7199e22ded03)

####After
![image](https://github.com/TelosLabs/giving-connection/assets/63365501/19b9ea7c-e5f2-4422-9f87-ece213685a3c)

