### PR TITLE
Hotfix | Unable to add days office hours as closed

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -105,6 +105,8 @@ class Location < ActiveRecord::Base
   end
 
   def blank_office_hours(attributes)
-    attributes['open_time'].blank? && attributes['close_time'].blank?
+    attributes['open_time'].blank? &&
+      attributes['close_time'].blank? &&
+      attributes['closed'].blank?
   end
 end


### PR DESCRIPTION
### Context
Creating  a new location on the admin panel with `non-standard office hours` option set to `none` and the seven days set to `closed` prompts the validation error `Office hours data is required for the 7 days of the week`.

### What changed
`Closed` attribute was not included in the method that rejects if all attributes of the office hours are blank.

### How to test it
Create a new location on the admin panel with `non-standard office hours` option set to `none` and the seven days set to `closed`
