### PR TITLE
[Google ads]: Tracking tags

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,3 +1,8 @@
+- content_for :head do
+  // Event snippet for Website traffic conversion page
+  javascript:
+    gtag('event', 'conversion', {'send_to': 'AW-11382454124/o0V1CIzO2O8YEOzuybMq'});
+
 main
   section class="relative bg-electric-teal hidden" data-controller="banner" data-banner-target="banner"
     div class="flex max-w-3xl mx-auto py-7 md:py-8"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,12 @@
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','<%= Rails.application.credentials.dig(Rails.env.to_sym)[:google_tag_key] %>');
     </script>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-11382454124"></script>
+    <script>
+      window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'AW-11382454124');
+    </script>
   </head>
 
   <body class="bg-gray-9">


### PR DESCRIPTION
### Context
_Google ads_ require the addition of some "Tracking tags" to measure the traffic and conversion rate of the clicks on Giving Connection's ads.
### What changed
Added the following tags to the `views/layouts/application.html` template and the home page (please read [here](https://support.google.com/google-ads/answer/6331314#zippy=%2Cset-up-conversion-tracking-using-the-google-tag%2Ccheck-your-conversion-tracking-tag) for more information)

Application Layout
```
<!-- Google tag (gtag.js) --> <script async src="https://www.googletagmanager.com/gtag/js?id=AW-11382454124"></script> <script> window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'AW-11382454124'); </script> 
```
Home template
```
<!-- Event snippet for Website traffic conversion page --> <script> gtag('event', 'conversion', {'send_to': 'AW-11382454124/o0V1CIzO2O8YEOzuybMq'}); </script> 
```

### How to test it
The client will check if these are tracking correctly with their Google ads account.

### References

[ClickUp ticket](https://app.clickup.com/t/86ayv24w5)
