### PR TITLE
Fix/search alert email button on mobile

### DIFF
--- a/app/views/saved_search_alert_mailer/send_alert.html.erb
+++ b/app/views/saved_search_alert_mailer/send_alert.html.erb
@@ -29,7 +29,7 @@
 </div>
 <div class="sm-px-0" style="margin: 0px; margin-top: 48px; padding-left: 24px; padding-right: 24px;">
   <div style="text-align: center;">
-    <%= link_to 'EXPLORE MORE NONPROFITS', search_url, target: "_blank", style: "width: 200px; height: 39px; margin-left: 0; margin-right: 0; padding: 10px 20px; font-weight: 700; text-decoration: none; background: #0782D0; border-radius: 6px; color: white;" %>
+    <%= link_to 'MORE NONPROFITS', search_url, target: "_blank", style: "width: 200px; height: 39px; margin-left: 0; margin-right: 0; padding: 10px 20px; font-weight: 700; text-decoration: none; white-space: nowrap; background: #0782D0; border-radius: 6px; color: white;" %>
   </div>
   <div style="margin-top: 40px;">
     <p style="margin: 0px; font-size: 14px;"><%= "This email was intended for #{@alert.user.email}" %></p>


### PR DESCRIPTION
### What changed
* Shortened text of CTA in search alert email template. From "EXPLORE MORE NONPROFITS" to "MORE NONPROFITS".
### References
[ClickUp ticket](https://app.clickup.com/t/86ayvrapn)