### PR TITLE
Feature/Add Donate and Volunteer Buttons to Discover Page Cards

### DIFF
--- a/app/components/discover_nonprofit_card/component.html.slim
+++ b/app/components/discover_nonprofit_card/component.html.slim
@@ -17,6 +17,11 @@ article class="rounded text-xs font-medium bg-white shadow-md overflow-hidden"
     section class="relative pt-4 pb-7 text-gray-4 font-normal"
       h3 class="absolute h-0 w-0 opacity-0" head
       = render DiscoverNonprofitCard::Head::Component.new(location: @location)
+    // Donate/Volunteer buttons
+    - if has_donation_or_volunteer_link?(@location)
+      section class="w-full relative"
+        h3 class="sr-only" altruistic menu
+        = render "locations/donate_volunteer_buttons", location: @location, container_styles: "flex gap-x-4 w-full pt-5 pb-3 border-t border-gray-8 text-base"
     // Actions menu
     section class="pt-6 pb-11 border-t border-gray-8"
       h3 class="h-0 w-0 opacity-0" actions menu

--- a/app/components/discover_nonprofit_card/component.rb
+++ b/app/components/discover_nonprofit_card/component.rb
@@ -1,4 +1,6 @@
 class DiscoverNonprofitCard::Component < ApplicationViewComponent
+  include LocationsHelper
+
   def initialize(user:, location:)
     @user = user
     @location = location

--- a/app/views/locations/_donate_volunteer_buttons.html.slim
+++ b/app/views/locations/_donate_volunteer_buttons.html.slim
@@ -6,7 +6,7 @@ div class=local_assigns[:container_styles]
       class: "centered-flex w-full gap-2 py-3 border-0 rounded-md font-bold transition-colors text-indigo-700 bg-indigo-100 hover:bg-indigo-200",\
       target: "_blank",\
     ) do
-      = image_tag "donate-icon.svg", class: "w-7 h-7"
+      = image_tag "donate-icon.svg", class: "w-7 h-7", alt: "Donate icon"
       | Donate
 
   - if local_assigns[:location].organization.volunteer_availability? && local_assigns[:location].organization.volunteer_link.present?
@@ -16,6 +16,6 @@ div class=local_assigns[:container_styles]
       class: "centered-flex w-full gap-2 p-3 border-0 rounded-md font-bold transition-colors text-blue-dark bg-seafoam hover:bg-electric-teal",\
       target: "_blank"\
     ) do
-      = image_tag "volunteer-icon.svg", class: "w-7 h-7"
+      = image_tag "volunteer-icon.svg", class: "w-7 h-7", alt: "Volunteer icon"
       | Volunteer
       


### PR DESCRIPTION
### What changed
* Added `donate_volunteer_buttons` partial to `discover_nonprofit_card` component.
* Improved image accessibility inside buttons
### How to test it
1. Go to admin panel and create a new **Org Admin**
2. Go back to your account on the "My nonprofit pages"
3. Edit the nonprofit by adding donate and volunteer buttons
4. Go to the Discover page and search that nonprofit
### References
[ClickUp ticket](https://app.clickup.com/t/86ayhm1dm)
## Demo
![Screenshot 2024-02-09 at 11 13 39 a m  (2)](https://github.com/TelosLabs/giving-connection/assets/62576509/525486f2-0364-4e6e-8f8d-350098db173f)