### PR TITLE
Fix overflow in advanced filters

### DIFF
--- a/app/components/select_multiple/component.html.erb
+++ b/app/components/select_multiple/component.html.erb
@@ -1,7 +1,7 @@
 <%= content_tag :div, options do %>
-  <div class="flex flex-wrap flex-shrink-0 max-w-full gap-2 py-2 pl-2" data-select-multiple-target="badgesContainer">
+  <div class="flex flex-wrap flex-shrink-0 max-w-full gap-2 p-2" data-select-multiple-target="badgesContainer">
   </div>
-  <input id="<%= @required ? 'required':'' %>" type="text" data-select-multiple-target="input" class="h-full text-sm align-middle border-0 border-transparent scroll-mt-25 focus:outline-none focus:border-transparent focus:ring-0 rounded-6px pt-3 w-48" data-action="select-multiple#search" placeholder="<%= @placeholder %>">
+  <input id="<%= @required ? 'required':'' %>" type="text" data-select-multiple-target="input" class="w-48 h-full pt-3 text-sm align-middle border-0 border-transparent scroll-mt-25 focus:outline-none focus:border-transparent focus:ring-0 rounded-6px" data-action="select-multiple#search" placeholder="<%= @placeholder %>">
   <div data-search-target="advancedFiltersCheckboxes" data-extend-dropdown-target="menu" class="absolute left-0 z-10 hidden w-full mt-2 top-full max-h-52" >
     <div class="p-5 overflow-y-auto bg-white border rounded border-gray-5 max-h-52">
       <div class="flex flex-col gap-y-2">
@@ -24,7 +24,7 @@
           <% else %>
             <% @items&.sort&.each do |item| %>
               <div class="" data-select-multiple-target="group">
-                <div class="flex gap-x-2 items-center">
+                <div class="flex items-center gap-x-2">
                   <%= check_box_tag "#{@name}[]", item, false, class: "h-4 w-4 rounded-6px text-base text-blue-medium focus:border-0 focus:ring-0 focus:ring-transparent modal-checkbox",
                                     data: { 'select-multiple-target': "checkbox", action: 'click->select-multiple#select', value: item } %>
                   <% if Cause.find_by(name: item) %>
@@ -67,7 +67,7 @@
     </div>
   </div>
   <%# Badge Template %>
-  <span class="hidden bg-blue-medium py-1.5 pl-2 pr-1 min-h-7 inline-flex items-center text-xs text-white flex-shrink-0 rounded-6px" data-select-multiple-target="badgeTemplate">
+  <span class="hidden bg-blue-medium py-1.5 pl-2 pr-1 min-h-7 inline-flex items-center text-xs text-white rounded-6px" data-select-multiple-target="badgeTemplate">
     <span>
     </span>
     <button type="button" data-action='click->select-multiple#remove' class="flex-shrink-0 ml-0.5 h-4 w-4 rounded-full inline-flex items-center justify-center text-indigo-400 hover:bg-indigo-200 hover:text-indigo-500 focus:outline-none focus:bg-indigo-500 focus:text-white">


### PR DESCRIPTION
### Context

When you select a long service category like “Services to Promote Specific Populations” it spills outside the advanced filters box

### What changed

#### Before:
<img width="344" alt="image" src="https://github.com/TelosLabs/giving-connection/assets/67963195/ac75a363-abe9-4a7a-a83d-75388f7b54bb">

#### After: 
<img width="378" alt="image" src="https://github.com/TelosLabs/giving-connection/assets/67963195/d845db84-f637-4ef6-af07-1c8390ad8c90">


### How to test it

Go to advanced filters and select a long service name 

### References

[ClickUp ticket](https://app.clickup.com/t/85yx52u7f)
