### PR TITLE
Fix tooltip position

### DIFF
--- a/app/components/location_infowindow/component.html.slim
+++ b/app/components/location_infowindow/component.html.slim
@@ -11,7 +11,7 @@ div class="flex items-center gap-1"
   a id="pointer"
     = link_to @location.name, location_path(@location), target:"_blank", class: "text-small font-bold text-gray-2"
   - if @location.organization.verified?
-    = render partial: "shared/popover", locals: {position: "left-0", copy: "Information verified by nonprofit.", wrapper_icon: "verified_nonprofit_check.svg"}
+    = render partial: "shared/popover", locals: {position: "right-0", copy: "Information verified by nonprofit.", wrapper_icon: "verified_nonprofit_check.svg"}
 
 // Address, website, phone, and availability
 - if @location.public_address?

--- a/app/components/result_card/component.html.erb
+++ b/app/components/result_card/component.html.erb
@@ -11,7 +11,7 @@
         <div class="flex items-start">
           <%= helpers.title_link(@turbo_frame, @id, @title) %>
           <% if @verified %>
-            <%= render "shared/popover", copy: "Information verified by nonprofit.", wrapper_icon: "verified_nonprofit_check.svg" %>
+            <%= render "shared/popover", copy: "Information verified by nonprofit.", wrapper_icon: "verified_nonprofit_check.svg", position: "right-0" %>
           <% end %>
         </div>
 

--- a/app/views/shared/_popover.html.erb
+++ b/app/views/shared/_popover.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="popover">
+<div data-controller="popover" class="relative">
   <span data-action="mouseenter->popover#show mouseleave->popover#hide" data-popover-target="popover">
     <%= inline_svg_tag local_assigns[:wrapper_icon], class: "h-4 ml-1" %>
   </span>


### PR DESCRIPTION
### Context

The tooltip appeared in an odd position when the checkmark was in a result card occupying a place other than the first one. 
### What changed

#### Before
<img width="442" alt="image" src="https://github.com/TelosLabs/giving-connection/assets/67963195/5a8974dd-e21f-4a7b-aaee-deede02d6096">



#### After
<img width="375" alt="image" src="https://github.com/TelosLabs/giving-connection/assets/67963195/e0d3441c-b5a6-4ff2-823d-716eeabdbdba">


### How to test it

### References

[ClickUp ticket](url)
