### PR TITLE
Fix | Authentication after devise upgrade

### DIFF
--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -1,8 +1,8 @@
 .main
-  h2 class="pb-10 text-2xl font-bold text-center pt-14 md:pt-32 md:mt-2 text-gray-gray-7"
+  h2 class="pt-14 pb-10 text-2xl font-bold text-center md:pt-32 md:mt-2 text-gray-gray-7"
     | Create a new Password
 
-  div class="max-w-md px-4 mx-auto mb-5 text-sm text-center text-black pb-7 sm:text-lg sm:pb-12"
+  div class="px-4 pb-7 mx-auto mb-5 max-w-md text-sm text-center text-black sm:text-lg sm:pb-12"
     | Please create a new password
 
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
@@ -13,4 +13,4 @@
       = form_group_for f, :password_confirmation do
         = f.password_field :password_confirmation, autocomplete: "new-password", class: "c-input", placeholder: "Confirm your password"
       .c-form--action
-        = f.submit "Reset password", class:"c-button"
+        = f.submit "Reset password", class:"c-button", data: { turbo: false }

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -1,8 +1,8 @@
 .main
-  h2 class="pb-10 text-2xl font-bold text-center pt-14 md:pt-32 md:mt-2 text-gray-gray-7"
+  h2 class="pt-14 pb-10 text-2xl font-bold text-center md:pt-32 md:mt-2 text-gray-gray-7"
     | Reset your password?
   
-  div class="max-w-md px-4 mx-auto text-sm text-center text-black pb-7 sm:text-lg sm:pb-12"
+  div class="px-4 pb-7 mx-auto max-w-md text-sm text-center text-black sm:text-lg sm:pb-12"
     | Forgot your password? Please enter the email associated with your account so we can help you.
 
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
@@ -10,4 +10,4 @@
       = form_group_for f, :email, label: "Email Address", class: "mb-6" do 
         = f.email_field :email, autofocus: true, autocomplete: "email", class:"c-input"
       .c-form--action class="mt-12 mb-44"
-        = f.submit "Send reset instructions", class:"c-button"
+        = f.submit "Send reset instructions", class:"c-button", data: { turbo: false}

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -1,5 +1,5 @@
 .main
-  h2 class="px-12 pb-6 text-2xl font-bold text-center pt-14 md:pt-20 md:mt-2 md:pb-9 text-gray-gray-7"
+  h2 class="px-12 pt-14 pb-6 text-2xl font-bold text-center md:pt-20 md:mt-2 md:pb-9 text-gray-gray-7"
     ' Create an account
     | on Giving Connection
 
@@ -15,10 +15,10 @@
     div class="absolute top-0 right-0 pr-20 -z-1 xl:pr-40"
       = inline_svg_tag 'desk-purple-blur-signup.svg'
 
-  div class="max-w-md px-6 mx-auto text-center pb-7 sm:text-lg sm:pb-12"
+  div class="px-6 pb-7 mx-auto max-w-md text-center sm:text-lg sm:pb-12"
     | While our search experience is free and available to everyone, you can create an account to have a more personalized experience.
 
-  div class="max-w-sm px-6 mx-auto mb-14 sm:px-1 sm:text-lg text-gray-gray-7"
+  div class="px-6 mx-auto mb-14 max-w-sm sm:px-1 sm:text-lg text-gray-gray-7"
     div class="flex pb-2"
       div class="flex items-center mr-4"
         = inline_svg_tag 'green-check.svg', size: '16*16'
@@ -37,17 +37,17 @@
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
     .c-form
       = form_group_for f, :name do
-        = f.text_field :name, autocomplete: "name", class:"c-input"
+        = f.text_field :name, autocomplete: "name", class:"c-input", data: { test_id: "signup_name_input"}
       = form_group_for f, :email, label: 'Email Address' do
-        = f.email_field :email, autocomplete: "email", class:"c-input"
+        = f.email_field :email, autocomplete: "email", class:"c-input", data: { test_id: "signup_email_input"}
       = form_group_for f, :password do
-        = f.password_field :password, autocomplete: "new-password", class:"c-input", placeholder: "(6+ characters)"
+        = f.password_field :password, autocomplete: "new-password", class:"c-input", placeholder: "(6+ characters)", data: { test_id: "signup_password_input"}
       = form_group_for f, :password_confirmation do
-        = f.password_field :password_confirmation, autocomplete: "new-password", class: "c-input", placeholder: "Confirm your password"
+        = f.password_field :password_confirmation, autocomplete: "new-password", class: "c-input", placeholder: "Confirm your password", data: { test_id: "signup_password_confirmation_input"}
       .c-form--action
-        = f.submit "Create Account", class:"c-button"
+        = f.submit "Create Account", class:"c-button", data: { test_id: "signup_submit_btn", turbo: false }
 
-  div class="max-w-sm px-8 mx-auto text-xs text-center pb-28 sm:pb-36"
+  div class="px-8 pb-28 mx-auto max-w-sm text-xs text-center sm:pb-36"
     ' By continuing, you agree to Giving Connection’s
     = link_to 'Terms & Conditions ', '#', class:'font-bold'
     ' and

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -257,7 +257,7 @@ Devise.setup do |config|
   # Lists the formats that should be treated as navigational. Formats like
   # :html, should redirect to the sign in page when the user does not have
   # access, but formats like :xml or :json, should return 401.
-  #
+  config.navigational_formats = %i[html turbo_stream]
   # If you have any extra navigational formats, like :iphone or :mobile, you
   # should add them to the navigational formats lists.
   #

--- a/spec/system/user_registration_system_spec.rb
+++ b/spec/system/user_registration_system_spec.rb
@@ -1,0 +1,15 @@
+require "system_helper"
+
+RSpec.describe "User Registration", type: :system do
+  it "can register" do
+    visit signup_path
+
+    find(:test_id, "signup_name_input").fill_in with: "Jane Doe"
+    find(:test_id, "signup_email_input").fill_in with: "jane@example.com"
+    find(:test_id, "signup_password_input").fill_in with: "password"
+    find(:test_id, "signup_password_confirmation_input").fill_in with: "password"
+    click_button "signup_submit_btn"
+
+    expect(page).to have_content("Welcome! You have signed up successfully.")
+  end
+end


### PR DESCRIPTION
### Context

Password reset and registration failed after upgrading Devise.

### What changed

Remove workaround (Turbo failure app)  and set turbo false in devise forms. 

### How to test it

### References

[ClickUp ticket](url)
