### PR TITLE
refactor: remove (CST) time zone

### DIFF
--- a/app/decorators/location_decorator.rb
+++ b/app/decorators/location_decorator.rb
@@ -17,13 +17,13 @@ class LocationDecorator < ApplicationDecorator
   def working_hours
     return "Closed" if open_time_for_display.nil? && close_time_for_display.nil?
 
-    "#{open_time_for_display} - #{close_time_for_display} (CST)"
+    "#{open_time_for_display} - #{close_time_for_display}"
   end
 
   def display_day_working_hours(office_hour)
     return "Closed" if office_hour&.closed?
 
-    "#{office_hour&.open_time&.strftime("%l:%M %p")} - #{office_hour&.close_time&.strftime("%l:%M %p")} (CST)"
+    "#{office_hour&.open_time&.strftime("%l:%M %p")} - #{office_hour&.close_time&.strftime("%l:%M %p")}"
   end
 
   def open_time_for_display

--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -338,8 +338,6 @@
                             span.sr-only Dismiss
                             = inline_svg_tag 'x-icon.svg', class:'h-3 w-3'
                         p class="mb-6 text-sm text-gray-4"
-                          | Hours must be entered in Central Standard Time (CST).
-                          br
                           | Please enter times for each day of the week to avoid an error message.
                         // For horizontal scrolling
                         div class="overflow-x-auto my-10 w-full"


### PR DESCRIPTION
### Context
The customer has a demo in Atlantic City and currently the app displays hours of operation in (CST). These changes remove that time zone from the text displayed, but a better and more robust approach has to be taken.
### What changed
Removed "(CST)" from decorators and modals.
### How to test it

### References

[ClickUp ticket](https://app.clickup.com/t/86b06e7ma)
