### PR TITLE
Fix office hour time zone method

### DIFF
--- a/app/models/office_hour.rb
+++ b/app/models/office_hour.rb
@@ -54,7 +54,8 @@ class OfficeHour < ActiveRecord::Base
   end
 
   def time_zone
-    ActiveSupport::TimeZone[location&.time_zone] || default_time_zone
+    location_time_zone = location&.time_zone.presence || ""
+    ActiveSupport::TimeZone[location_time_zone] || default_time_zone
   end
 
   private

--- a/spec/models/office_hour_spec.rb
+++ b/spec/models/office_hour_spec.rb
@@ -18,4 +18,21 @@ RSpec.describe OfficeHour, type: :model do
     it { is_expected.to validate_presence_of(:open_time) }
     it { is_expected.to validate_presence_of(:close_time) }
   end
+
+  describe "methods" do
+    describe "#time_zone" do
+      it "is expected to return time zone as Time Zone object" do
+        expect(office_hour.time_zone).to be_a(ActiveSupport::TimeZone)
+      end
+
+      it "is expected to have a name that matches the location's time zone " do
+        expect(office_hour.time_zone.name).to eql(location.time_zone)
+      end
+
+      it "is expected to fallback to default time zone if location time zone is not present" do
+        location.time_zone = nil
+        expect(office_hour.time_zone.name).to eql("Eastern Time (US & Canada)")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

From logs:
ActionView::Template::Error (invalid argument to TimeZone[]: nil):

### What changed

Fix the time zone method in the office hour model to handle nil values. 

### How to test it

### References

[ClickUp ticket](url)
