### PR TITLE
Fix | My no profit map pin

### DIFF
--- a/app/javascript/controllers/places_controller.js
+++ b/app/javascript/controllers/places_controller.js
@@ -106,7 +106,6 @@ export default class extends Controller {
         this.longitudeValue || this.getCookie("longitude") || Number(this.longitudeTarget.value) || -86.78125827725053
         ),
       zoom: this.zoomLevel(),
-      gestureHandling: 'auto',
       mapTypeControl: true,
       mapTypeControlOptions: {
         style: google.maps.MapTypeControlStyle.DROPDOWN_MENU,


### PR DESCRIPTION
### Context

The center of the map in the location show page was tied to the location selected in the nav bar.

### What changed

The center of the map is now tied to the map pin. 

### How to test it

### References

[ClickUp ticket](https://app.clickup.com/t/86b0xxw53)
