### PR TITLE
added microsoft conversion tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,14 +13,12 @@
     </script>
     <!-- Microsoft tag -->
     <script>
-    window.uetq = window.uetq || [];
-    window.uetq.push('set', { 'pid': { 
-      'em': '<%= current_user&.email %>', // Replace with the variable that holds the user's email address. 
-      'ph': '<%= current_user&.phone_number %>', // Replace with the variable that holds the user's phone number. 
-   } });
+      window.uetq = window.uetq || [];
+      window.uetq.push('set', { 'pid': {
+        'em': '<%= current_user&.email %>'
+         } });
     </script>
     <!-- Conversion UET tag -->
-
     <title>Giving Connection</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <% if request.fullpath.include? "/search" %>


### PR DESCRIPTION
We would like to add pixels to the following buttons/actions: 

1. Search Platform
2. Search Tab - URL Contains: /search
3. Keyword Search Button - URL Contains: keyword%
4. Nonprofit Page - URL Contains: /locations
5. Nonprofit web address - May need to create a hubspot link?
6. All donate buttons (platform, nonprofit pages, discover page)
7. Donate tab - URL Contains: .org/donate
8. Donate Button - When users successfully donate through givebutter, how do we track? 
9. Donate Button for Nonprofits - May need to create a hubspot link?
10. All volunteer buttons (platform, nonprofit pages, discover page) - May need to create a hubspot link?
11. The Create Account button - URL Contains: .org/sign up
12. Can we track when they actually sign up through the banner trigger or the email sent? 
13. The discover tab on the top navigation bar - URL Contains: .org/discover
14. Cause Icons - URL Contains: .org/discover..."cause"