### PR TITLE
Remove whitespace discover

### DIFF
--- a/app/views/causes/index.html.slim
+++ b/app/views/causes/index.html.slim
@@ -20,7 +20,7 @@ div class="flex flex-col text-gray-2"
       = inline_svg_tag 'simple-star.svg', size: '22*22'
 
 div class="px-6"
-  section class="flex relative flex-col items-center text-center text-gray-2 md:flex-row md:justify-center md:mt-14"
+  section class="flex relative flex-col items-center text-center text-gray-2 md:flex-row md:justify-center md:mt-4"
     div class="flex flex-col items-center pt-20 max-w-lg md:relative md:w-3/5 md:pt-0"
       h2 class="mb-6 text-2xl font-bold"
         | Shine a light on good
@@ -32,7 +32,7 @@ div class="px-6"
       = inline_svg_tag "blur-background-1", class: "absolute top-0 -z-1 w-full max-w-md md:-top-1/2"
     = inline_svg_tag "browse-by-causes.svg", class: "w-full max-w-md -mt-6 md:w-2/5"
 
-  section class="flex flex-col items-center pt-6 mb-28 md:pt-28 md:mb-44" id="causes-section"
+  section class="flex flex-col items-center pt-4 mb-6 md:pt-6 md:mb-28" id="causes-section"
     h2 class="mb-10 text-2xl font-bold tracking-tight text-gray-2 dark:text-white md:mb-14"
       | Causes
 


### PR DESCRIPTION
### Context

There is alot of dead space at the top of the discover page. Let's remove some of that so the user can see the top portion of the causes and know the intended use of this page. 

### What changed

Some space above "Shine a light on good" was removed; some space above "Causes" was removed. User can now see "Causes" without having to scroll.

### How to test it

### References

https://app.clickup.com/t/86b0e26kd
