### PR TITLE
Fix/enforce sign up form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,7 @@ GEM
     pundit (2.4.0)
       activesupport (>= 3.0.0)
     racc (1.8.1)
-    rack (2.2.11)
+    rack (2.2.13)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-mini-profiler (2.3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,9 +332,9 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.3-arm64-darwin)
+    nokogiri (1.18.5-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.3-x86_64-linux-gnu)
+    nokogiri (1.18.5-x86_64-linux-gnu)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,10 +32,25 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable,
     :rememberable, :validatable, :confirmable, :lockable, :trackable
 
+  # Validations
+  validates :name, presence: true,
+    length: {minimum: 2, maximum: 50},
+    format: {with: /\A[a-zA-Z\s\-']+\z/, message: "can only contain letters, spaces, hyphens and apostrophes"}
+
+  validate :no_urls_in_name
+
   has_many :organizations, as: :creator
   has_many :alerts
   has_many :fav_locs, class_name: "FavoriteLocation"
   has_many :favorited_locations, through: :fav_locs, source: :location
   has_many :organization_admin
   has_many :administrated_organizations, through: :organization_admin, source: :organization
+
+  private
+
+  def no_urls_in_name
+    if name.present? && name.match?(/https?:\/\/|\.[a-z]{2,}/i)
+      errors.add(:name, "cannot contain URLs or web links")
+    end
+  end
 end

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome <%= @user&.name %>,</p>
+<p>Welcome <%= sanitize(@user&.name&.truncate(50)) %>,</p>
 <p>We are thrilled you are joining the Giving Connection community. We look forward to serving your nonprofit needs by making finding help and serving others easier.</p>
 <p style = "margin-bottom: 30px;">You can confirm your account email through the link below:</p>
 <div style = "text-align: center;">

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -44,6 +44,10 @@
         = f.password_field :password, autocomplete: "new-password", class:"c-input", placeholder: "(6+ characters)", data: { test_id: "signup_password_input"}
       = form_group_for f, :password_confirmation do
         = f.password_field :password_confirmation, autocomplete: "new-password", class: "c-input", placeholder: "Confirm your password", data: { test_id: "signup_password_confirmation_input"}
+      // Honeypot
+      = invisible_captcha
+      div class="w-full"
+        = recaptcha_tags
       .c-form--action
         = f.submit "Create Account", class:"c-button hover:bg-seafoam-light transition", data: { test_id: "signup_submit_btn", turbo: false }
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,14 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :redis_cache_store, {
+      url: ENV.fetch("REDISCLOUD_URL", "redis://localhost:6379/1"),
+      reconnect_attempts: 1,
+      error_handler: ->(method:, returning:, exception:) {
+        Rails.logger.error "Redis cache error: #{exception.message}"
+      }
+    }
+
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,26 +1,30 @@
+require "rack/attack"
+
 class Rack::Attack
   ### Configure Cache ###
 
-  # Configure Rack::Attack to use Redis with namespace and key expiry
-  CACHE_PREFIX = "rack_attack".freeze
+  CACHE_PREFIX = "rack::attack".freeze
 
-  # Use Redis for storing throttle data with automatic key expiry
-  Rack::Attack.cache.store = Redis::Store.new(
-    url: ENV.fetch("REDISCLOUD_URL") { ENV.fetch("REDIS_URL", "redis://localhost:6379/0") },
-    namespace: CACHE_PREFIX,
-    expires_in: 1.day # Global TTL for keys
+  # Use Redis as our cache backend
+  Rack::Attack.cache.store = Redis.new(
+    url: ENV.fetch("REDISCLOUD_URL", "redis://localhost:6379/1"),
+    reconnect_attempts: 1,
+    timeout: 1
   )
 
-  class << self
-    private
-
-    # Helper method to create Redis keys with size limits
-    def cache_key_with_limits(key, max_size = 1024)
-      # Ensure key doesn't exceed maximum size to prevent memory issues
-      key = key.to_s
-      key = key[0...max_size] if key.length > max_size
-      "#{CACHE_PREFIX}:#{key}"
-    end
+  # Development-specific settings for easier testing
+  THROTTLE_PERIODS = if Rails.env.development?
+    {
+      registration_ip: 5.minutes,      # Instead of 1 hour
+      suspicious_domain: 5.minutes,    # Instead of 1 hour
+      login: 20.seconds               # Keep as is for login
+    }.freeze
+  else
+    {
+      registration_ip: 1.hour,
+      suspicious_domain: 1.hour,
+      login: 20.seconds
+    }.freeze
   end
 
   ### Throttle Spammy Clients ###
@@ -34,19 +38,17 @@ class Rack::Attack
   # quickly. If so, enable the condition to exclude them from tracking.
 
   # Throttle all requests by IP (60rpm)
-  #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
   throttle("req/ip", limit: 300, period: 5.minutes) do |req|
-    cache_key_with_limits("ip:#{req.ip}") unless req.path.start_with?("/assets")
+    req.ip unless req.path.start_with?("/assets")
   end
 
   ### Prevent Registration Spam ###
 
   # Throttle new account registrations by IP
-  # Allow 3 registrations per IP per hour
-  throttle("registrations/ip", limit: 3, period: 1.hour) do |req|
+  throttle("registrations/ip", limit: 1, period: THROTTLE_PERIODS[:registration_ip]) do |req|
     if req.path == "/users" && req.post?
-      cache_key_with_limits("registration:ip:#{req.ip}")
+      Rails.logger.info "[Rack::Attack] Registration attempt from IP: #{req.ip}" if Rails.env.development?
+      req.ip
     end
   end
 
@@ -67,35 +69,66 @@ class Rack::Attack
   ].freeze
 
   # Stricter throttling for suspicious email domains
-  # (domains not in the allowed list)
-  throttle("registrations/suspicious_email_domain", limit: 2, period: 1.hour) do |req|
+  throttle("registrations/suspicious_email_domain", limit: 2, period: THROTTLE_PERIODS[:suspicious_domain]) do |req|
     if req.path == "/users" && req.post? && req.params["user"].present?
       email = req.params["user"]["email"].to_s
       domain = email.split("@").last.to_s.downcase if email.include?("@")
+
+      if Rails.env.development?
+        Rails.logger.info "[Rack::Attack] Registration email domain: #{domain}"
+        Rails.logger.info "[Rack::Attack] Is suspicious domain? #{!ALLOWED_EMAIL_PROVIDERS.include?(domain)}"
+      end
+
       if domain.present? && !ALLOWED_EMAIL_PROVIDERS.include?(domain)
-        cache_key_with_limits("registration:domain:#{domain}")
+        domain
       end
     end
   end
 
   # Return a custom error message for throttled registration attempts
-  Rack::Attack.throttled_responder = lambda do |env|
-    now = Time.zone.now
-    match_data = env["rack.attack.match_data"]
+  Rack::Attack.throttled_responder = lambda do |request|
+    now = Time.now.utc
+    match_data = request.env["rack.attack.match_data"]
+
+    Rails.logger.info "[Rack::Attack] Throttle triggered"
+    Rails.logger.info "[Rack::Attack] Match data: #{match_data.inspect}"
+    Rails.logger.info "[Rack::Attack] Request path: #{request.path}"
+    Rails.logger.info "[Rack::Attack] Client IP: #{request.ip}"
+
     period = match_data[:period]
     retry_after = period - (now.to_i % period)
+
+    # Determine the type of throttle that was triggered
+    throttle_type = case match_data[:discriminator]
+    when request.ip
+      "IP-based rate limit"
+    when ->(d) { d.is_a?(String) && d.include?(".") }
+      "Suspicious email domain"
+    else
+      "Rate limit"
+    end
 
     headers = {
       "Content-Type" => "application/json",
       "Retry-After" => retry_after.to_s
     }
 
+    message = case throttle_type
+    when "IP-based rate limit"
+      "Too many registration attempts from this IP address. Please try again in #{retry_after} seconds."
+    when "Suspicious email domain"
+      "Registration attempts from this email domain are temporarily restricted. Please try again in #{retry_after} seconds or use a different email provider."
+    else
+      "Too many attempts. Please try again in #{retry_after} seconds."
+    end
+
     [
       429,
       headers,
       [{
-        error: "Too many attempts. Please try again in #{retry_after} seconds.",
-        retry_after: retry_after
+        error: message,
+        retry_after: retry_after,
+        throttle_type: throttle_type
       }.to_json]
     ]
   end
@@ -110,26 +143,15 @@ class Rack::Attack
   # different IPs to try brute-forcing a password for a specific account.
 
   # Throttle POST requests to /login by IP address
-  #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/ip:#{req.ip}"
-  throttle("logins/ip", limit: 5, period: 20.seconds) do |req|
+  throttle("logins/ip", limit: 5, period: THROTTLE_PERIODS[:login]) do |req|
     if req.path == "/login" && req.post?
       req.ip
     end
   end
 
   # Throttle POST requests to /login by email param
-  #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:logins/email:#{normalized_email}"
-  #
-  # Note: This creates a problem where a malicious user could intentionally
-  # throttle logins for another user and force their login requests to be
-  # denied, but that's not very common and shouldn't happen to you. (Knock
-  # on wood!)
-  throttle("logins/email", limit: 5, period: 20.seconds) do |req|
+  throttle("logins/email", limit: 5, period: THROTTLE_PERIODS[:login]) do |req|
     if req.path == "/login" && req.post?
-      # Normalize the email, using the same logic as your authentication process, to
-      # protect against rate limit bypasses. Return the normalized email if present, nil otherwise.
       req.params["email"].to_s.downcase.gsub(/\s+/, "").presence
     end
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -80,7 +80,7 @@ class Rack::Attack
 
   # Return a custom error message for throttled registration attempts
   Rack::Attack.throttled_responder = lambda do |env|
-    now = Time.now
+    now = Time.zone.now
     match_data = env["rack.attack.match_data"]
     period = match_data[:period]
     retry_after = period - (now.to_i % period)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :user do
+    name { "Test User" }
     sequence(:email) { |n| "user#{n}@example.com" }
     password { "testing" }
     password_confirmation { "testing" }

--- a/spec/services/time_zone_converter_spec.rb
+++ b/spec/services/time_zone_converter_spec.rb
@@ -6,16 +6,19 @@ RSpec.describe TimeZoneConverter, type: :service do
     let(:time_str) { "13:00:00.00000" }
 
     it "converts the time to UTC and then converts it back" do
-      converter = described_class.new(local_time_zone)
-      utc_time = converter.to_utc(time_str)
+      Time.use_zone(local_time_zone) do
+        converter = described_class.new(local_time_zone)
+        local_time = Time.zone.parse(time_str)
+        utc_time = converter.to_utc(time_str)
 
-      expect(utc_time.zone).to eq("UTC")
-      expect(utc_time.hour).to eq(21)
+        expect(utc_time.zone).to eq("UTC")
+        expect(utc_time).to eq(local_time.utc)
 
-      original_time = converter.to_local(utc_time.strftime("%H:%M:%S"))
+        original_time = converter.to_local(utc_time.strftime("%H:%M:%S"))
 
-      expect(original_time.zone).to eq("PST")
-      expect(original_time.hour).to eq(13)
+        expect(original_time.zone).to eq("PDT")
+        expect(original_time.hour).to eq(13)
+      end
     end
 
     it "raises an error if the time given is invalid" do


### PR DESCRIPTION
### Context

Bots are using the sign up form to send spam emails to potential users. 

### What changed

1. Added reCaptcha and honey pot to the sign up form.
2. Name has to be between 2 and 50 characters, and a special check for links was added (links are not allowed now) 
3. Sanitize `name` in the confirmation email template so it does not display links as links .
4. Limit registration attempts per IP and restrict suspicious email domains.

### How to test it

### References

[ClickUp ticket](url)
