### PR TITLE
Fix Info Verification not getting highlighted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
     ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     formatador (1.1.0)
     friendly_id (5.5.1)
@@ -347,6 +348,8 @@ GEM
       net-protocol
     nio4r (2.7.4)
     nokogiri (1.18.8-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
@@ -626,6 +629,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -485,7 +485,7 @@
                   = social_media_form.label :blog, class: "block text-sm text-gray-3 font-medium"
                   = social_media_form.text_field :blog, { class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }
             div class="my-4 mt-6 border-t border-t-blue-pale"
-            section class="mt-6 text-gray-2 mb-[50vh]"
+            section class="mt-6 text-gray-2 md:mb-[40vh]"
               div class="grid grid-cols-12 gap-6"
                 div class="col-span-12 lg:col-span-6 md:col-span-7"
                   h3 class="flex items-center text-lg font-medium leading-7 text-blue-medium" id="information-verification" data-scrollspy-target="section"

--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -485,7 +485,7 @@
                   = social_media_form.label :blog, class: "block text-sm text-gray-3 font-medium"
                   = social_media_form.text_field :blog, { class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }
             div class="my-4 mt-6 border-t border-t-blue-pale"
-            section class="mt-6 text-gray-2"
+            section class="mt-6 text-gray-2 mb-[50vh]"
               div class="grid grid-cols-12 gap-6"
                 div class="col-span-12 lg:col-span-6 md:col-span-7"
                   h3 class="flex items-center text-lg font-medium leading-7 text-blue-medium" id="information-verification" data-scrollspy-target="section"


### PR DESCRIPTION
### Context
- Inside the edit organization view, the last section (Information Verification) was not being properly highlighted whenever it was selected from the sidebar or when scrolling it into view.

### What changed
- Whitespace has been added below the section so that it can come into view for the trigger to detect it and highlight it properly.
- Whitespace is disabled in mobile view. Since the sidebar is disabled in mobile, the whitespace isn't needed