### PR TITLE
Fix info header

### DIFF
--- a/app/javascript/controllers/scrollspy_controller.js
+++ b/app/javascript/controllers/scrollspy_controller.js
@@ -22,6 +22,9 @@ export default class extends Controller {
       if (section) this.observer.observe(section)
     })
 
+    this.boundScroll = this.checkBottomEntry.bind(this);
+    window.addEventListener("scroll", this.boundScroll);
+
   }
 
   handleIntersect(entries) {
@@ -46,6 +49,7 @@ export default class extends Controller {
 
   disconnect() {
     if (this.observer) this.observer.disconnect()
+    window.removeEventListener("scroll", this.boundScroll);
   }
 
   scrollToSection(event) {
@@ -114,5 +118,24 @@ export default class extends Controller {
       list.classList.add('hidden');
       chevron.classList.remove('rotate-90');
     }
-  }  
+  }
+  
+  checkBottomEntry() {
+    const el = document.getElementById("scrollable-content");
+    const rect = el.getBoundingClientRect();
+
+    console.log("Rect: ",rect.bottom)
+    console.log("Height:", window.innerHeight)
+  
+    if (rect.bottom <= window.innerHeight + 100) {
+      this.linkTargets.forEach(link => {
+        const isActive = link.dataset.sectionId === "information-verification"
+  
+        link.classList.toggle("text-blue-medium", isActive)
+        link.classList.toggle("font-medium", isActive)
+        link.classList.toggle("text-gray-3", !isActive)
+      })
+    }
+  }
+  
 }

--- a/app/javascript/controllers/scrollspy_controller.js
+++ b/app/javascript/controllers/scrollspy_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["link"]
+  scrolling = false
 
   connect() {
     this.sectionElements = this.linkTargets.map(link => {
@@ -20,6 +21,7 @@ export default class extends Controller {
     this.sectionElements.forEach(section => {
       if (section) this.observer.observe(section)
     })
+
   }
 
   handleIntersect(entries) {
@@ -28,6 +30,8 @@ export default class extends Controller {
       .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)[0]
 
     if (!visibleEntry) return
+
+    if (this.scrolling) return
 
     const visibleId = visibleEntry.target.id
 
@@ -46,7 +50,8 @@ export default class extends Controller {
 
   scrollToSection(event) {
     event.preventDefault()
-  
+    this.scrolling = true
+
     const sectionId = event.currentTarget.dataset.sectionId
     const section = document.getElementById(sectionId)
     if (!section) return
@@ -55,6 +60,18 @@ export default class extends Controller {
     const top = section.getBoundingClientRect().top + window.scrollY - offset
   
     window.scrollTo({ top, behavior: 'smooth' })
+    this.linkTargets.forEach(link => {
+      const isActive = link.dataset.sectionId === sectionId
+
+      link.classList.toggle("text-blue-medium", isActive)
+      link.classList.toggle("font-medium", isActive)
+      link.classList.toggle("text-gray-3", !isActive)
+    })
+
+    setTimeout(() => {
+      this.scrolling = false;
+    }, 1000);
+  
   }
 
   scrollToTop(event) {
@@ -98,6 +115,4 @@ export default class extends Controller {
       chevron.classList.remove('rotate-90');
     }
   }  
-  
-  
 }

--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -54,7 +54,7 @@
           | Back to top
         
 
-    div class="flex-1 w-3/4 scroll-pt-[181px]"
+    div class="flex-1 w-3/4 scroll-pt-[181px]" id="scrollable-content"
       div class="flex flex-col p-12 pt-6"
         = form_for(@organization, html: { id: "organization-form" }, data: @form_presenter&.change_detection_form_setup&.merge({controller: 'form-validation'})) do |f|
           section class="text-gray-2"
@@ -485,7 +485,7 @@
                   = social_media_form.label :blog, class: "block text-sm text-gray-3 font-medium"
                   = social_media_form.text_field :blog, { class: "block h-46px mt-1 h-full w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }
             div class="my-4 mt-6 border-t border-t-blue-pale"
-            section class="mt-6 text-gray-2 md:mb-[40vh]"
+            section class="mt-6 text-gray-2"
               div class="grid grid-cols-12 gap-6"
                 div class="col-span-12 lg:col-span-6 md:col-span-7"
                   h3 class="flex items-center text-lg font-medium leading-7 text-blue-medium" id="information-verification" data-scrollspy-target="section"


### PR DESCRIPTION
### Context
- The last section header was not being highlighted properly when reaching it, due to it not reaching the detection area due to it being too small.

### What changed
- When clicking a menu section, the section gets automatically highlighted without waiting for the element to arrive in view, and it also blocks any highlight sections for a brief time to give it time for the element to come into view.
- When manually scrolling, once you're about to reach the bottom, the last section gets highlighted, instead of waiting for the section to reach the "hitbox" near the top.
