### PR TITLE
fix map filter background

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -36,12 +36,15 @@ export default class extends Controller {
     this.displayAppliedIcon();
 
     this.skipUnsavedCheck = false;
+
+    document.addEventListener("turbo:submit-end", this._actuallyCloseModal.bind(this));
   }
 
   disconnect() {
     this.skipUnsavedCheck = true;
     this._actuallyCloseModal();
     this.close();
+    document.removeEventListener("turbo:submit-end", this._actuallyCloseModal.bind(this));
   }
 
   open(e) {

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -37,14 +37,15 @@ export default class extends Controller {
 
     this.skipUnsavedCheck = false;
 
-    document.addEventListener("turbo:submit-end", this._actuallyCloseModal.bind(this));
+    this.boundActuallyCloseModal = this._actuallyCloseModal.bind(this);
+    document.addEventListener("turbo:submit-end", this.boundActuallyCloseModal);
   }
 
   disconnect() {
     this.skipUnsavedCheck = true;
     this._actuallyCloseModal();
     this.close();
-    document.removeEventListener("turbo:submit-end", this._actuallyCloseModal.bind(this));
+    document.removeEventListener("turbo:submit-end", this.boundActuallyCloseModal);
   }
 
   open(e) {
@@ -255,7 +256,7 @@ export default class extends Controller {
     this.containerTarget.classList.add(this.toggleClass);
     if (this.background) this.background.remove();
   }
-  
+
   
   submitAndClose(event) {
     this.skipUnsavedCheck = true;


### PR DESCRIPTION
### Context
- The search page has an option to apply filters. When doing so, a modal appears and the background is obscured. When applying the changes, the modal disappears, but the obscured background remains. 

### What changed
- Added an event listener that fires the close function whenever the form gets submitted. The issue was that the function was not being run on time before the form reloaded the page, leaving the background behind.
