### PR TITLE
fix photo gallery

### DIFF
--- a/app/components/discover_nonprofit_card/images_carousel/component.html.slim
+++ b/app/components/discover_nonprofit_card/images_carousel/component.html.slim
@@ -1,7 +1,7 @@
-= content_tag(:div, carousel_container_options)
+= content_tag(:div, carousel_container_options.merge(class: "#{carousel_container_options[:class]} overflow-hidden w-full max-w-full"))
   = render DiscoverNonprofitCard::ImagesCarousel::NavButton::Component.new(direction: :prev, outline: "M15 19l-7-7 7-7")
 
-  div class="swiper-wrapper w-full"
+  div class="w-full swiper-wrapper"
     - @images.each do |image|
       img src=url_for(image) class="swiper-slide #{@image_styles} object-contain" alt="Slide #{@images.index(image) + 1} of #{@images.length}"
 


### PR DESCRIPTION
### Context
- The photo gallery was experiencing overflowing and overlapping on the z-index
<img width="1357" alt="Screenshot 2025-05-28 at 4 03 53 p m" src="https://github.com/user-attachments/assets/adb9ad9c-e3e3-4571-bb7f-3d5661a77776" />


### What changed
- The div was given classes to properly handle its contents
<img width="605" alt="Screenshot 2025-05-28 at 4 04 22 p m" src="https://github.com/user-attachments/assets/d72ebcf7-75bf-4e22-92e9-1312a776f7aa" />
