### PR TITLE
Fix terms policy

### DIFF
--- a/app/views/privacy_policies/show.html.slim
+++ b/app/views/privacy_policies/show.html.slim
@@ -294,7 +294,7 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
         ' info@givingconnection.org
       ' with “Privacy Policy” in the subject line; or
     li class="pb-2"
-      ' By postal mail: 304 Nantucket Drive, Cape May, NJ 08204
+      ' By postal mail: 3845 Bayshore Road Ste 26 #110, North Cape May, NJ 08204
   p class="pb-4"
     ' Our intent is to promptly reply to every message we receive. This information is used to respond directly to your questions or comments. We also may file your comments to improve our services in the future.
 

--- a/app/views/privacy_policies/show.html.slim
+++ b/app/views/privacy_policies/show.html.slim
@@ -355,5 +355,5 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
     a class="text-blue-medium" href="mailto:info@givingconnection.org"
       ' info@givingconnection.org
     ' call us at
-    a class="text-blue-medium" href="tel:+1-609-602-4959"
-      '(609) 602-4959.
+    a class="text-blue-medium" href="tel:+1-609-200-6234"
+      '(609) 200-6234

--- a/app/views/terms_and_conditions/show.html.slim
+++ b/app/views/terms_and_conditions/show.html.slim
@@ -346,7 +346,7 @@ div class="max-w-5xl px-6 pb-12 mx-auto text-justify main text-gray-3 sm:pb-6"
     ' Attention: DMCA
 
   p class="pb-4"
-    ' 304 Nantucket Drive
+    ' 3845 Bayshore Road Ste 26 #110
 
   p class="pb-4"
     ' Cape May, NJ 08204

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -53,8 +53,8 @@
         = f.check_box :terms_of_service, required: true
         label for="user_terms_of_service"
           |  I agree to Giving Connection’s  
-          = link_to 'Terms & Conditions', '#', class: 'text-blue-600 underline'
+          = link_to 'Terms & Conditions', terms_of_use_path, class: 'text-blue-600 underline', target: '_blank'
           |  and 
-          = link_to 'Privacy Policy', 'https://givingconnection.org/privacy-policy', class: 'text-blue-600 underline'
+          = link_to 'Privacy Policy', privacy_policy_path, class: 'text-blue-600 underline', target: '_blank'
       .c-form--action
         = f.submit "Create Account", class:"c-button hover:bg-seafoam-light transition", data: { test_id: "signup_submit_btn", turbo: false }


### PR DESCRIPTION
### Context
- The user signup page had policy links that were not working
- The phone number was outdated
- The address was outdates

### What changed
- The policy links were fixed
- The phone number was updated
- The address was updated


