### PR TITLE
Fix grayed backdrop when clicking too fast

### DIFF
--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -54,6 +54,11 @@ export default class extends Controller {
       e.preventDefault();
     }
 
+    if (!this.containerTarget || !this.containerTarget.classList) {
+      console.warn("Modal container not ready. Aborting open().");
+      return;
+    }
+x
     if (e.target.blur) {
       e.target.blur();
     }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -64,6 +64,11 @@ export default class extends Controller {
     // Unhide the modal
     this.containerTarget.classList.remove(this.toggleClass);
 
+    if (!this.containerTarget || this.containerTarget.classList.contains(this.toggleClass)) {
+      return;
+    }
+
+
     // Insert the background
     if (!this.data.get("disable-backdrop") && this.containerTarget) {
       document.body.insertAdjacentHTML("beforeend", this.backgroundHtml);

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -65,7 +65,7 @@ export default class extends Controller {
     this.containerTarget.classList.remove(this.toggleClass);
 
     // Insert the background
-    if (!this.data.get("disable-backdrop")) {
+    if (!this.data.get("disable-backdrop") && this.containerTarget) {
       document.body.insertAdjacentHTML("beforeend", this.backgroundHtml);
       this.background = document.querySelector(`#${this.backgroundId}`);
     }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -54,11 +54,6 @@ export default class extends Controller {
       e.preventDefault();
     }
 
-    if (!this.containerTarget || !this.containerTarget.classList) {
-      console.warn("Modal container not ready. Aborting open().");
-      return;
-    }
-x
     if (e.target.blur) {
       e.target.blur();
     }


### PR DESCRIPTION
### Context
- When clicking advanced filters before all of the information finishes loading, the backdrop would remain with no way of exiting,

### What changed
- The backdrop now cannot be generated if it hasn't finished loading everything else