### PR TITLE
add partnership links

### DIFF
--- a/app/views/about_us/show.html.slim
+++ b/app/views/about_us/show.html.slim
@@ -296,22 +296,22 @@ div class="flex flex-col text-gray-2"
         | We have collaborated with <span class="font-bold">Dell Technologies</span> on pro bono strategic workshops and with 
         | <span class="font-bold">Hack4Impact at Rutgers University</span> to co-develop features like our Community Calendar of Events. 
         | Our organizational journey has also been strengthened through participation in world-class programs, 
-        | including the 2023 Global Social Impact House in Costa Rica, hosted by the 
+        | including the <a target="_blank" href="https://csis.upenn.edu/residential-program/gsih/" class="italic underline">2023 Global Social Impact House</a> in Costa Rica, hosted by the 
         | <span class="font-bold">University of Pennsylvania’s Center for Social Impact Strategy</span>, and the 
         | <span class="font-bold">2025 Amazon Web Services (AWS) & Deloitte Social Entrepreneur Accelerator</span> in Cape Town, South Africa.
         <br><br>
         | We are also deeply proud of our summer internship program, launched in partnership with the 
-        | <span class="font-bold">CS+Social Good initiative at Stanford University</span>. This program provides students with meaningful, 
+        | <a target="_blank" href="https://cs4good.com/" class="italic underline">CS+Social Good initiative at Stanford University</a>. This program provides students with meaningful, 
         | hands-on opportunities to apply their skills to real-world social impact work, while contributing 
         | directly to Giving Connection’s growth, design, and development. Their creativity and commitment 
         | continue to shape the future of our platform.
         <br><br>
         | Our story and our mission has been featured in 
-        | <a href="https://www.nytimes.com/2024/12/27/style/stephanie-morrison-scott-platt-wedding.html" class="italic underline">The New York Times</a>, 
+        | <a target="_blank" href="https://www.nytimes.com/2024/12/27/style/stephanie-morrison-scott-platt-wedding.html" class="italic underline">The New York Times</a>, 
         | where Stephanie’s rain-soaked Hawaiian wedding ceremony which included her beloved Aunt Fran drew 
         | national attention to the heart behind Giving Connection. In 2025, we were honored to see our 
         | founder recognized with the 
-        | <a href="https://sjmagazine.net/featured/2025-women-of-excellence" class="italic underline">SJ Magazine Women of Excellence Inspiration Award</a>, 
+        | <a target="_blank" href="https://sjmagazine.net/featured/2025-women-of-excellence" class="italic underline">SJ Magazine Women of Excellence Inspiration Award</a>, 
         | a celebration of the deep humanity, joy, and innovation that fuel our work.
         <br><br>
 


### PR DESCRIPTION
### Context
- Some links were missing in the "Our Partnership" section.

### What changed
- The proper links were added to the section.
- The <a> tags were modified to open their links in a new tab
