### PR TITLE
Locations page fixes

### DIFF
--- a/app/components/working_hours/component.html.slim
+++ b/app/components/working_hours/component.html.slim
@@ -18,7 +18,7 @@ p class="text-sm leading-6 font-base text-gray-2"
       | Open
   - elsif @result.offer_services == false
     span class="text-states-error"
-      | This location does not offer services
+      | The listed address does not offer services. See website for more information.
   - else
     span class="text-states-error"
       | Closed

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -2,11 +2,13 @@ class OrganizationDecorator < ApplicationDecorator
   delegate_all
 
   def donation_link
-    object.decorate.url(object.donation_link)
+    link = object.donation_link.to_s
+    return "mailto:#{link}" if link.match?(/\A[^@\s]+@[^@\s]+\z/)
+    url_or_nil(link)
   end
 
   def volunteer_link
-    object.decorate.url(object.volunteer_link)
+    url_or_nil(object.volunteer_link)
   end
 
   def designation_copies
@@ -28,4 +30,14 @@ class OrganizationDecorator < ApplicationDecorator
       }
     end
   end
+
+  private
+
+  def url_or_nil(link)
+    uri = URI.parse(link)
+    return link if uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+  rescue URI::InvalidURIError, TypeError
+    nil
+  end
+
 end

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -35,9 +35,8 @@ class OrganizationDecorator < ApplicationDecorator
 
   def url_or_nil(link)
     uri = URI.parse(link)
-    return link if uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+    link if uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
   rescue URI::InvalidURIError, TypeError
     nil
   end
-
 end


### PR DESCRIPTION
### Context
- Whenever a location didn't have hours, a text was displayed indicating so.
- An organization can have an email address as a donation link, but the website didn't support mail-to's.

### What changed
- The text was changed to clarify the meaning behind it.
- Email address links were added for support.
