### PR TITLE
Remove tooltip glitch

### DIFF
--- a/app/components/save_button/component.html.erb
+++ b/app/components/save_button/component.html.erb
@@ -2,7 +2,7 @@
 <%= link_to(
       link_args[:path],
       method: link_args[:method],
-      class: "#{btn_selector} #{button_styles} relative",
+      class: "group #{btn_selector} #{button_styles} relative",
       data: { turbo_stream: true}
     ) do %>
   <%= render CauseIcon::Component.new(
@@ -10,7 +10,7 @@
         wrapper_options: { class: "pop-out labelled-icon #{wrapper_styles}", "aria-labelledby": tooltip_id },
         svg_options: { class: "w-4 h-auto", aria_hidden: true }
       ) %>
-  <span role="tooltip" id="<%= tooltip_id %>" class="<%= "hidden absolute z-10 px-2 py-1 w-44 text-xs text-white bg-opacity-90 rounded-lg transform bg-gray-2 #{@tooltip_position}" %>" >
+  <span role="tooltip" id="<%= tooltip_id %>" class="<%= "pointer-events-none absolute z-10 px-2 py-1 w-44 text-xs text-white bg-opacity-90 rounded-lg transform bg-gray-2 #{@tooltip_position} opacity-0 group-hover:opacity-100 transition" %>" >
     <% if @removable_fav_location %>
       Remove this nonprofit from your account
     <% else %>

--- a/app/components/save_button/component.html.erb
+++ b/app/components/save_button/component.html.erb
@@ -14,7 +14,7 @@
     <% if @removable_fav_location %>
       Remove this nonprofit from your account
     <% else %>
-      Save this nonprofit to you account!
+      Save this nonprofit to your account!
     <% end %>
   </span>
   <span class="<%= copy_styles %>">Save</span>

--- a/app/views/favorite_locations/create.turbo_stream.erb
+++ b/app/views/favorite_locations/create.turbo_stream.erb
@@ -2,13 +2,15 @@
   <%= render SaveButton::Component.new(
     user: @new_favorite_location.user,
     location: @new_favorite_location.location,
-    simplified: true
+    simplified: true,
+    tooltip_position: "right-0 mt-2"
   ) %>
 <% end %>
 
 <%= turbo_stream.replace_all(".save-location-#{@location.id}-btn") do %>
   <%= render SaveButton::Component.new(
     user: @new_favorite_location.user,
-    location: @new_favorite_location.location
+    location: @new_favorite_location.location,
+    tooltip_position: "top-10"
   ) %>
 <% end %>

--- a/app/views/favorite_locations/destroy.turbo_stream.erb
+++ b/app/views/favorite_locations/destroy.turbo_stream.erb
@@ -1,9 +1,9 @@
 <%= turbo_stream.replace_all(".save-location-#{@location.id}-btn__simplified") do %>
-  <%= render SaveButton::Component.new(user: @user, location: @location, simplified: true) %>
+  <%= render SaveButton::Component.new(user: @user, location: @location, simplified: true, tooltip_position: "right-0 mt-2") %>
 <% end %>
 
 <%= turbo_stream.replace_all(".save-location-#{@location.id}-btn") do %>
-  <%= render SaveButton::Component.new(user: @user, location: @location) %>
+  <%= render SaveButton::Component.new(user: @user, location: @location, tooltip_position: "top-10") %>
 <% end %>
 
 <%# Remove the entire saved page card from My Account page %>


### PR DESCRIPTION
### Context
When a user clicked on the save button for a nonprofit on the search page, the tooltip would reposition itself on top of the button and start glitching out. This is also related to another ticket where the tooltip would be cut off when you hover over the "Save" icon in the [7 Medium Priority - Design Elements](https://app.clickup.com/t/86b5p1qkq) ticket.

### What changed
Added a group class to the save button to enable tooltip visibility on hover when using group-hover property.

Removed hidden property because I hypothesized Turbo Stream was causing the tooltip to constantly appear and disappear because it kept adding and removing the hidden property. Instead, I used the opacity-0 property so it would always remain in the DOM, but it would be invisible.

The tooltip would reposition itself after a user clicked on the save button because the Turbo Stream files forgot to define the tooltip_position instance variable whenever it rerendered the HTML. Defined tooltip_position to have the same properties as result_card/component.html.erb and discover_nonprofit_card/actions_menu/component.html.slim.

### How to test it
On the Search webpage, hover over one of the nonprofits' bookmark icon and click on it. Observe how the bookmark icon changes colors and the tooltip field stays in the same position. The text changes from "save this nonprofit to your account!" to "remove this nonprofit from your account".


Unclick the bookmark icon and observe how the tooltip field stays in the same position. The text changes from "remove this nonprofit from your account" to "save this nonprofit to your account!".

Then, click on the name of the nonprofit. Then hover over the "Save" button. Click the save button and note how the bookmark icon changes colors but the tooltip field stays in the same positon. The text changes from "save this nonprofit to your account!" to "remove this nonprofit from your account".

Unclick the bookmark icon and observe how the tooltip field stays in the same position. The text changes from "remove this nonprofit from your account" to "save this nonprofit to your account!".

### References

[ClickUp ticket](https://app.clickup.com/t/86b5p1t1c)
