### PR TITLE
change redirection from relative path to absolute url

### DIFF
--- a/app/components/causes_list/component.html.slim
+++ b/app/components/causes_list/component.html.slim
@@ -1,7 +1,7 @@
 = content_tag(:ul, @list_options) do
   - @causes.each do |cause|
     li
-      = content_tag(:a, path(cause)) do
+      = content_tag(:a, cause.name, href: link_url(cause), data: { turbo: false }) do
         = content_tag(:div, cause_options) do
           span aria-labelledby=@tooltip_id class="labelled-icon"
             = render CauseIcon::Component.new(svg_name: "causes_categories/#{cause.decorate.svg_file_name}", \

--- a/app/components/causes_list/component.rb
+++ b/app/components/causes_list/component.rb
@@ -10,10 +10,8 @@ class CausesList::Component < ApplicationViewComponent
     @tooltip_id = SecureRandom.hex
   end
 
-  def path(cause)
-    {
-      href: discover_show_path(cause)
-    }
+  def link_url(cause)
+    discover_show_url(cause)
   end
 
   def cause_options


### PR DESCRIPTION
### Context
When a user clicked on one of the small causes icon on one of the nonprofits' discovery profiles in the Search tab, instead of redirecting to that cause's discovery webpage, it displayed "Content missing."

### What changed
Clicking on a cause icon caused a Turbo Frame error because the link was inside a Turbo Frame but lacked an href attribute and returned a relative path. This caused Turbo to try loading the response inside the frame instead of redirecting to another webpage. I renamed the method to link_url to clarify that it returns an absolute URL, added the proper href to the link, and ensured it redirected users to the cause’s discovery webpage.

### How to test it
On the Search tab, click on multiple causes icons under a nonprofit's discovery profile. Observe if clicking on the cause icon redirects you to the right "Browse by Causes" webpage. For example, hover over the "Health" icon and click on it. It should redirect you to a webpage with the heading "Health".

### References

[ClickUp ticket](https://app.clickup.com/t/86b5p1rz5)
https://stackoverflow.com/questions/75738570/getting-a-turbo-frame-error-of-content-missing
