### PR TITLE
remove tabsWrapper static target to prevent overlapping components

### DIFF
--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -18,9 +18,8 @@ export default class extends Controller {
     "filtersIcon",
     "panel",
     "tab",
-    "searchPillsPanel",
-    "tabsWrapper"
-  ]
+    "searchPillsPanel"
+  ] 
 
   static values = {
     currentExpandedCategory: String,
@@ -73,7 +72,7 @@ export default class extends Controller {
     this.isMobileValue = window.innerWidth <= 768
     
     // Update the wrapper class when switching between mobile and desktop
-    if (wasMobile !== this.isMobileValue) {
+    if (wasMobile !== this.isMobileValue && this.hasTabsWrapperTarget) {
       this.tabsWrapperTarget.classList.toggle('is-mobile', this.isMobileValue)
       
       // Reset state when switching between mobile and desktop


### PR DESCRIPTION
### Context
On mobile Safari browser, when a user selected search pills and then refreshed, the List and Map buttons would overlap the search pills. When a user refreshes, the search pills should be hidden, but they remain open, causing the overlap. This bug was only observed on mobile Safari browsers. 

### What changed
Static targets assume the DOM element always exists when the controller connects, but tabsWrapper is missing on mobile. To fix this, I removed tabsWrapper from static targets and implemented a conditional check using hasTabsWrapperTarget before applying any logic to tabsWrapper.

### How to test it
Go to Safari, turn on Developer mode, switch to Enter Responsive Design Mode, switch to iPhone Pro Max mode, click on any filter category, apply one or more search pills, reload the webpage, and observe whether the List and Map buttons are overlapping the search pills. The search pills option window should be hidden after reload.

### References

[ClickUp ticket](https://app.clickup.com/t/86b5p1t50)
https://stimulus.hotwired.dev/reference/targets
