### PR TITLE
added opacity styling to disabled class

### DIFF
--- a/app/javascript/controllers/general_population_controller.js
+++ b/app/javascript/controllers/general_population_controller.js
@@ -23,10 +23,16 @@ export default class extends Controller {
         population.dispatchEvent(clickEvent);
       });
 
-      this.specificPopulationsContainerTarget.classList.add(this.disabledClass);
+      const classes = this.data.get("disabledClass").split(' ');
+      classes.forEach(className => {
+        this.specificPopulationsContainerTarget.classList.add(className);
+      });
     }
     else {
-      this.specificPopulationsContainerTarget.classList.remove(this.disabledClass);
+      const classes = this.data.get("disabledClass").split(' ');
+      classes.forEach(className => {
+        this.specificPopulationsContainerTarget.classList.remove(className);
+      });
     }
   }
 

--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -221,7 +221,7 @@
                 | if you would like to add a population you serve that is not currently found in the list below.
 
               div class="grid grid-cols-12 gap-6 mt-8"
-                div class="col-span-12 lg:col-span-6 md:col-span-7" data-controller="options general-population" data-options-options-value=@beneficiaries data-general-population-disabled-class="pointer-events-none"
+                div class="col-span-12 lg:col-span-6 md:col-span-7" data-controller="options general-population" data-options-options-value=@beneficiaries data-general-population-disabled-class="opacity-50 pointer-events-none"
                   = f.label :beneficiary_subcategories, "Which target populations (beneficiaries) does your organization serve?", class: "block text-sm text-gray-3 font-medium"
                   p class="mt-2 mb-5 text-sm text-gray-4"
                     | Selections should only be made if your organization specifically serves that group through your programs. If your organization generally serves all populations, check the box 


### PR DESCRIPTION
### Context
When a user clicked "We generally serve all populations," the pointer becomes disabled, but there's no visual indicator that the option to open the dropdown menu was disabled.

### What changed
Updated general_populations controller to support multiple classes via disabledClass controller attribute. Applied opacity-50 for disabled input visual styling

### How to test it
Edit a nonprofit page
Scroll down to the Populations Served section
Add a single population
Check "We generally serve all populations" checkbox
Observe the input box turn a lighter gray
Uncheck the "we generally serve all populations" checkbox
Observe the input box return back to a darker gray

### References
This pr only targets a portion of this Clickup ticket. 
[ClickUp ticket](https://app.clickup.com/t/86b5p1qkq)
