### PR TITLE
Implement real-time UI feedback for phone and email validation

### DIFF
--- a/app/javascript/controllers/email_validation_controller.js
+++ b/app/javascript/controllers/email_validation_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    static targets = ["input", "formatError"]
+
+    connect() {
+        this.inputTarget.addEventListener("input", this.validateEmail.bind(this));
+    }
+
+    validateEmail() {
+        const email = this.inputTarget.value.trim();
+        const isValidFormat = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+        if (!isValidFormat && email.length > 0) {
+            this.inputTarget.classList.add(
+                "border-red-500",
+                "text-red-600",
+                "focus:border-red-500",
+                "focus:ring-red-500"
+            );
+            this.formatErrorTarget.classList.remove("hidden");
+            this.inputTarget.setAttribute("aria-invalid", "true");
+        } else {
+            this.inputTarget.classList.remove(
+                "border-red-500",
+                "text-red-600",
+                "focus:border-red-500",
+                "focus:ring-red-500"
+            );
+            this.formatErrorTarget.classList.add("hidden");
+            this.inputTarget.removeAttribute("aria-invalid");
+        }
+    }
+}

--- a/app/javascript/controllers/phone_number_validation_controller.js
+++ b/app/javascript/controllers/phone_number_validation_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+    static targets = ["input", "formatError"]
+
+    connect() {
+        this.inputTarget.addEventListener("input", this.validatePhoneNumber.bind(this));
+        this.inputTarget.addEventListener("keypress", this.filterInput.bind(this));
+    }
+
+    validatePhoneNumber() {
+        const number = this.inputTarget.value.trim();
+        const cleanedNumber = number.replace(/-/g, '');
+        const isValidFormat = /^\+?\d{10,15}$/.test(cleanedNumber);
+
+        if (!isValidFormat && number.length > 0) {
+            this.inputTarget.classList.add(
+                "border-red-500",
+                "text-red-600",
+                "focus:border-red-500",
+                "focus:ring-red-500"
+            );
+            this.formatErrorTarget.classList.remove("hidden");
+            this.inputTarget.setAttribute("aria-invalid", "true");
+        } else {
+            this.inputTarget.classList.remove(
+                "border-red-500",
+                "text-red-600",
+                "focus:border-red-500",
+                "focus:ring-red-500"
+            );
+            this.formatErrorTarget.classList.add("hidden");
+            this.inputTarget.removeAttribute("aria-invalid");
+        }
+    }
+
+    filterInput(event) {
+        const allowedChars = /[0-9+\-]/;
+        const char = String.fromCharCode(event.which);
+
+        if (!allowedChars.test(char)) {
+            event.preventDefault();
+        }
+    }
+}

--- a/app/views/organizations/edit.html.slim
+++ b/app/views/organizations/edit.html.slim
@@ -301,12 +301,19 @@
 
                     div class="col-span-12 lg:col-span-6 md:col-span-7" id="location-specific-fields"
                       = location_form.fields_for :phone_number, PhoneNumber.find_or_initialize_by(location: location_form.object) do |phone_form|
-                        = phone_form.label :number, "Phone", class: "block text-sm text-gray-3 font-medium"
-                        = phone_form.text_field :number, { class: "block h-46px mt-1 w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium" }
+                        div data-controller = "phone-number-validation"
+                          = phone_form.label :number, "Phone", class: "block text-sm text-gray-3 font-medium"
+                          = phone_form.text_field :number, { class: "block h-46px mt-1 w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium", data: { "phone-number-validation-target": "input" } }
+                          p.text-sm.text-red-500.mt-1.hidden data-phone-number-validation-target="formatError"
+                            | Please enter a valid phone number (10-15 digits, optional +, hyphens allowed).  
+                            | Example: +1-800-555-1234
 
-                      div class="hidden col-span-3 md:flex"
-                      = location_form.label :email, "Email", class:"block text-sm text-gray-3 font-medium pt-4"
-                      = location_form.text_field :email, class: "block h-46px mt-1 w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium"
+                      div class="hidden col-span-3 md:flex" 
+                        div data-controller="email-validation" class="w-full flex flex-col"
+                          = location_form.label :email, "Email", class:"block text-sm text-gray-3 font-medium pt-4"
+                          = location_form.text_field :email, class: "block h-46px mt-1 w-full py-0 px-4 rounded-6px border-gray-5 text-base text-gray-3 focus:ring-blue-medium focus:border-blue-medium", data: { "email-validation-target": "input" } 
+                          p.text-sm.text-red-500.mt-1.hidden data-email-validation-target="formatError"
+                                | Please enter a valid email address. Example: user@example.com
 
                       div class="hidden col-span-3 md:flex"
                       = location_form.label :youtube_video_link, "YouTube Video Link", class:"block text-sm text-gray-3 font-medium pt-4"


### PR DESCRIPTION
### Context
When a user filled out the phone number and email section of their "Main Location" or any "Additional Location", they could send invalid inputs. 

### What changed
Created phone number and email validation controllers that verify user input against specified regex patterns. Change the input field to red, change the input text to red, and display an error message below stating that their input is invalid. Similar changes to EIN validation PR. 

### How to test it
Navigate to My Nonprofit Pages
Edit a nonprofit 
Scroll down to "Main Location"
Input a single digit in the phone number field
Observe the text turn red, the border turn red, and a short sentence below the input field stating the input is invalid
Check these cases: inputting any number of digits short of 10, any number of digits greater than 15, any other character besides + / - / digit, multiple +'s 
Hyphens are cleaned from the input text when checking for input validation in the phone number controller
Repeat steps but for an "Additional Location"

Navigate to My Nonprofit Pages
Edit a nonprofit 
Scroll down to "Main Location"
Input a single character in the email field
Observe the text turn red, the border turn red, and a short sentence below the input field stating the input is invalid
Check these cases: inputting no @, inputting more than one @, inputting no periods, inputting more than one period, inputting a period or @ as the first character, inputting no characters between @ and period, inputting a space in the middle of the email 
Hyphens are cleaned from the input text when checking for input validation in the phone number controller
Repeat steps but for an "Additional Location"

### References
This PR only fulfills a portion of the clickup ticket
[ClickUp ticket](https://app.clickup.com/t/86b5p1qkq)
