### PR TITLE
add spinner for long full page loads

### DIFF
--- a/app/javascript/controllers/navigation_load_controller.js
+++ b/app/javascript/controllers/navigation_load_controller.js
@@ -1,0 +1,48 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    document.addEventListener('turbo:before-fetch-request', this.handleFetchRequest)
+    document.addEventListener('turbo:before-render', this.handleBeforeRender)
+  }
+
+  disconnect() {
+    document.removeEventListener('turbo:before-fetch-request', this.handleFetchRequest)
+    document.removeEventListener('turbo:before-render', this.handleBeforeRender)
+
+    this.element.querySelectorAll('a').forEach(link => {
+      if (!this.isLocalLink(link)) {
+        link.removeEventListener('click', this.scrollToTop)
+      }
+    })
+  }
+
+  // Show spinner when Turbo starts fetching a full page navigation
+  handleFetchRequest = (event) => {
+    const target = event.target
+    const isFullPageReload = target === document.documentElement || target === document.body || target === document
+
+    if (isFullPageReload) {
+      this.spinnerTimeout = setTimeout(() => {
+        const spinner = document.getElementById("global-spinner")
+        if (spinner) spinner.classList.remove("hidden")
+      }, 1000) // show spinner if page doesn't load after 1 second
+    }
+  }
+
+  // Cancel spinner when Turbo is about to render new content
+  handleBeforeRender = () => {
+    clearTimeout(this.spinnerTimeout)
+    const spinner = document.getElementById("global-spinner")
+    if (spinner) spinner.classList.add("hidden")
+  }
+
+  isLocalLink(link) {
+    return (
+      link.hostname === window.location.hostname &&
+      !link.href.startsWith('mailto:') &&
+      !link.href.startsWith('tel:') &&
+      !link.hash 
+    )
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
   </head>
   <body
   class="bg-gray-9"
-  data-controller="disable-turbo geolocation"
+  data-controller="disable-turbo geolocation navigation-load"
   data-disable-turbo-target-urls-value="<%= turbo_disabled_urls %>"
   data-action="turbo:click@document->disable-turbo#disableTurboForTargetUrls">
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= Rails.application.credentials.dig(Rails.env.to_sym, :google_tag_key) %>"
@@ -53,6 +53,9 @@
     </main>
     <%= render Footer::Component.new() %>
     <div id="main-modal-container"></div>
+    <div id="global-spinner" class="hidden fixed inset-0 flex items-center justify-center bg-white bg-opacity-70 z-50">
+      <div class="spinner"></div>
+    </div>
     <script src="https://cdn.jsdelivr.net/gh/stevenschobert/instafeed.js@2.0.0rc1/src/instafeed.min.js"></script>
     <script>
       (function(){ var s = document.createElement('script'); var h = document.querySelector('head') || document.body; s.src = 'https://acsbapp.com/apps/app/dist/js/app.js'; s.async = true; s.onload = function(){ acsbJS.init({ statementLink : '', footerHtml : '', hideMobile : false, hideTrigger : false, disableBgProcess : false, language : 'en', position : 'right', leadColor : '#146FF8', triggerColor : '#146FF8', triggerRadius : '50%', triggerPositionX : 'right', triggerPositionY : 'bottom', triggerIcon : 'people', triggerSize : 'bottom', triggerOffsetX : 20, triggerOffsetY : 20, mobile : { triggerSize : 'small', triggerPositionX : 'right', triggerPositionY : 'bottom', triggerOffsetX : 20, triggerOffsetY : 20, triggerRadius : '20' } }); }; h.appendChild(s); })();


### PR DESCRIPTION
### Context
When a user attempts to navigate away from their current page, sometimes the user would be confused because it seemed like nothing happened. Instead, the page was still rendering, but there was no visual indicator. 

### What changed
Added a navigation-load controller that adds a spinner when the webpage takes longer than a second to load. 

### How to test it
Go to DevTools -> Network
Change "No throttling" to "3G" to purposely activate slow page rendering
Click on either the Search or Discover tab
Observe the background turn white and a loading spinner appear in the center of the webpage
Once the page loads, the viewport should scroll to the top, ensuring the user is oriented at the top

Alternatively, change the delay in navigation_load_controller.js on line 29 to a shorter delay if you want to see the loading spinner quicker

### References
https://developer.mozilla.org/en-US/docs/Web/Performance/Guides/How_long_is_too_long
[ClickUp ticket](https://app.clickup.com/t/86b1ft0rm)
