### PR TITLE
Set a default image for attach flyer

### DIFF
--- a/app/views/events/form.html.slim
+++ b/app/views/events/form.html.slim
@@ -94,7 +94,7 @@ div.flex.justify-center.mt-16.h-full style="background-color: #F9FAFC"
           | Attach Flyer/Photo    
       div.flex.justify-start
           div.flex.flex-col.items-center
-              img.outline.outline-1.outline-gray-700 style="background: #E6E6E6; height: 148px; width:148px;" id="uploaded-img2"
+              img.outline.outline-1.outline-gray-700 style="background: #E6E6E6; height: 148px; width:148px;" id="uploaded-img2" src=asset_path("default_logo_1.svg")
               - if @event.image.attached?
                 javascript:
                   document.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
### Context
There is no image link displayed when a user is filling out the form to create a new event for the Community Calendar feature.

### What changed
Added a default image link with src using the default_logo_1.svg image. 

### How to test it
Navigate to My Account
Click Create Event
Scroll to the bottom of the form
Observe how the image below "Attach Flyer/Photo" has a heart image

### References
Row 23
https://docs.google.com/spreadsheets/d/1GMeHn5YZKzjkbgjPGWyeuCUyzgGHIZ93uN0QjD1uRS8/edit?gid=0#gid=0
