### PR TITLE
My profile redirect

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -11,7 +11,6 @@ const application = Application.start()
 application.register('carousel', Carousel)
 application.register('autocomplete', Autocomplete)
 application.register('dropdown', Dropdown)
-application.register("calendar-component", CalendarComponentController)
 const context = require.context(".", true, /_controller\.js$/)
 const contextComponents = require.context("../../components", true, /_controller\.js$/)
 application.load(


### PR DESCRIPTION
### Context
After logging in, when you click "My Account" it takes you directly to 'My Events" rather than to the default which is "My Profile".

This is critical - every PR fails because of the "log out" test that is fixed with this PR.

### What changed
Removed a line of code in app/javascript/controllers/index.js that attempted to manually load the calendar component controller before it was registered.

### How to test it
Go to My Account
Click between every tab
Observe how you can visit every tab

### References
Row 3
[Bug Sheet](https://docs.google.com/spreadsheets/d/158klFxrZFr_UkGeR5DnvHWpxj3JB-oIDO8Z57gvgHaA/edit?gid=0#gid=0)
