### PR TITLE
Saved pages alerts

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -37,7 +37,7 @@ class AlertsController < ApplicationController
     return unless @alert.update(alert_params)
 
     flash[:notice] = "Alert updated!"
-    redirect_to my_account_path
+    redirect_to my_account_path()
   end
 
   def destroy

--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -37,7 +37,7 @@ class AlertsController < ApplicationController
     return unless @alert.update(alert_params)
 
     flash[:notice] = "Alert updated!"
-    redirect_to my_account_path()
+    redirect_to my_account_path
   end
 
   def destroy

--- a/app/views/my_accounts/show.html.slim
+++ b/app/views/my_accounts/show.html.slim
@@ -3,16 +3,16 @@ div class="w-full h-full bg-white"
     h2 class="mb-6 text-2xl font-bold text-center text-grey-2 md:text-left"
       | My Account
     div
-      div data-controller="tabs" data-tabs-active-tab="border-blue-medium text-blue-medium"
-        nav class="flex overflow-x-auto px-6 -mb-px space-x-6 text-grey-5" aria-label="Tabs"
+      div data-controller="tabs" data-tabs-active-tab="border-blue-medium text-blue-medium" 
+        nav class="flex overflow-x-auto px-6 -mb-px space-x-6 text-grey-5" aria-label="Tabs" data-turbo="false"
           /! Current: "border-indigo-500 text-indigo-600", Default: "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
-          a class="px-1 py-4 mb-4 text-sm font-medium whitespace-nowrap border-b-2 border-transparent hover:text-blue-medium hover:border-blue-medium" href="#" data-action="click->tabs#change" data-tabs-target="tab"
+          a class="px-1 py-4 mb-4 text-sm font-medium whitespace-nowrap border-b-2 border-transparent hover:text-blue-medium hover:border-blue-medium" href="#" data-action="click->tabs#change" data-tabs-target="tab" data-tab-name="profile"
             | My Profile
-          a class="px-1 py-4 mb-4 text-sm font-medium whitespace-nowrap border-b-2 border-transparent hover:text-blue-medium hover:border-blue-medium" href="#" data-action="click->tabs#change" data-tabs-target="tab"
+          a class="px-1 py-4 mb-4 text-sm font-medium whitespace-nowrap border-b-2 border-transparent hover:text-blue-medium hover:border-blue-medium" href="#" data-action="click->tabs#change" data-tabs-target="tab" data-tab-name="bookmarks"
             | Saved Pages
-          a class="px-1 py-4 mb-4 text-sm font-medium whitespace-nowrap border-b-2 border-transparent hover:text-blue-medium hover:border-blue-medium" aria-current="page" href="#" data-action="click->tabs#change" data-tabs-target="tab"
+          a class="px-1 py-4 mb-4 text-sm font-medium whitespace-nowrap border-b-2 border-transparent hover:text-blue-medium hover:border-blue-medium" aria-current="page" href="#alerts" data-action="click->tabs#change" data-tabs-target="tab" data-tab-name="alerts"
             | Alerts
-          a class="px-1 py-4 mb-4 text-sm font-medium whitespace-nowrap border-b-2 border-transparent hover:text-blue-medium hover:border-blue-medium" href="#" data-action="click->tabs#change" data-tabs-target="tab"
+          a class="px-1 py-4 mb-4 text-sm font-medium whitespace-nowrap border-b-2 border-transparent hover:text-blue-medium hover:border-blue-medium" href="#" data-action="click->tabs#change" data-tabs-target="tab" data-tab-name="my-nonprofit"
             | My Nonprofit Pages
 
         div class="hidden px-6" data-tabs-target="panel"


### PR DESCRIPTION
### Context
When a user deleted an saved alert from their profile, they would be redirected to the default "My Profile page." I first attempted to track the anchors, but when Turbo replaces DOM components, it overrides the link hash. 

### What changed
Refactored the tab controller to use custom data attributes to persist the active tab across panel view switches. Turbo will not override any attributes for DOM elements. 

### How to test it
Go to Search and create a Search Alert
Go to My Account
Go to Alerts
Click edit 
Change the Alert Frequency and click save
Observe how the modal closes and you are still on the Alert Page
Click edit again
Click "delete alert"
Observe how the modal closes and you are still on the Alert Page
To ensure the update did not change tab switching functionality, switch between all tabs to make sure no errors pop up

### References

[ClickUp ticket](https://app.clickup.com/t/85yx52u7j)
