### PR TITLE
separating js code from explore.html.slim and redirect users to nonprofit after clicking logo in events

### DIFF
--- a/app/javascript/controllers/event_logo_controller.js
+++ b/app/javascript/controllers/event_logo_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static values = { profileUrl: String }
+
+    redirectToProfile(event) {
+        event.preventDefault()
+
+        if (this.hasProfileUrlValue) {
+            window.location.href = this.profileUrlValue
+        } else {
+            console.error("Organization profile URL not provided.")
+        }
+    }
+}

--- a/app/javascript/controllers/events_controller.js
+++ b/app/javascript/controllers/events_controller.js
@@ -1,0 +1,121 @@
+// app/javascript/controllers/events_controller.js
+import { Controller } from "@hotwired/stimulus"
+import $ from "jquery"
+import moment from "moment"
+
+export default class extends Controller {
+  static targets = ["list", "calendar", "listButton", "calendarButton", "filters", "daterange"]
+  static values = { 
+    numParams: Number,
+    daterangeParam: String 
+  }
+
+  connect() {
+    this.initializeDaterangePicker()
+  }
+
+  toggleList(event) {
+    const isList = event.currentTarget.dataset.type === "list"
+    
+    if (isList) {
+      // Show list and hide calendar
+      this.listTarget.classList.remove('hidden')
+      this.calendarTarget.classList.add('hidden', 'h-0', 'w-0')
+      
+      // Change button styles
+      this.listButtonTarget.classList.add('bg-gray-200')
+      this.calendarButtonTarget.classList.remove('bg-gray-200')
+    } else {
+      // Hide list
+      this.listTarget.classList.add('hidden')
+      
+      // Show calendar container with proper dimensions 
+      this.calendarTarget.classList.remove('hidden', 'h-0', 'w-0')
+      
+      // Change button styles
+      this.listButtonTarget.classList.remove('bg-gray-200')
+      this.calendarButtonTarget.classList.add('bg-gray-200')
+
+      if (window.calendar) {
+        window.calendar.render()
+      }
+    }
+  }
+
+  showFilters(event) {
+    const show = event.currentTarget.dataset.show === "true"
+    
+    if (show) {
+      this.filtersTarget.classList.remove('hidden')
+    } else {
+      this.filtersTarget.classList.add('hidden')
+    }
+  }
+
+  clearFilters() {
+    window.location.href = '/events/explore'
+  }
+
+  parseDateRange(dateRangeStr) {
+    if (!dateRangeStr) return { start: null, end: null }
+    
+    // Decode URL-encoded characters
+    const decodedStr = decodeURIComponent(dateRangeStr)
+    
+    // Split by the hyphen to get start and end parts
+    const parts = decodedStr.split(' - ')
+    if (parts.length !== 2) return { start: null, end: null }
+    
+    const startStr = parts[0]
+    const endStr = parts[1]
+    
+    // Parse dates directly with moment
+    const startDate = moment(startStr, 'M/D hh:mm A')
+    const endDate = moment(endStr, 'M/D hh:mm A')
+    
+    return {
+      start: startDate.isValid() ? startDate : null,
+      end: endDate.isValid() ? endDate : null
+    }
+  }
+
+  initializeDaterangePicker() {
+    if (!this.hasDaterangeTarget) return
+    
+    // Initialize daterangepicker with appropriate options
+    const daterangepickerOptions = {
+      timePicker: true,
+      autoUpdateInput: false, // Don't update input until user selects a date range
+      locale: {
+        format: 'M/D h:mm A',
+        cancelLabel: 'Clear',
+        applyLabel: 'Apply'
+      },
+      drops: 'up',
+      opens: 'center'
+    }
+    
+    // Only set startDate and endDate if there's a valid daterange parameter
+    if (this.daterangeParamValue) {
+      const parsedDates = this.parseDateRange(this.daterangeParamValue)
+      if (parsedDates.start && parsedDates.end) {
+        daterangepickerOptions.startDate = parsedDates.start
+        daterangepickerOptions.endDate = parsedDates.end
+        daterangepickerOptions.autoUpdateInput = true // Update input with the existing date range
+      }
+    }
+    
+    // Initialize daterangepicker
+    const dateRangePicker = $(this.daterangeTarget).daterangepicker(daterangepickerOptions)
+    
+    // Add event listeners to update the input value when user selects a date range
+    dateRangePicker.on('apply.daterangepicker', (ev, picker) => {
+      $(this.daterangeTarget).val(picker.startDate.format('M/D h:mm A') + ' - ' + picker.endDate.format('M/D h:mm A'))
+    })
+    
+    // Clear the input when user cancels
+    dateRangePicker.on('cancel.daterangepicker', (ev, picker) => {
+      $(this.daterangeTarget).val('')
+    })
+  }
+}

--- a/app/views/events/event.html.slim
+++ b/app/views/events/event.html.slim
@@ -1,4 +1,4 @@
-div class="w-[75vw] mx-auto mt-6 p-3 flex justify-between gap-4 mb-24"
+div class="w-[75vw] mx-auto mt-6 p-3 flex justify-between gap-4 mb-24" data-controller="event-logo"  data-event-logo-profile-url-value=location_path(@event.organization.locations.first)
     div class="flex flex-col gap-3 w-2/3 rounded-md bg-white"
         img src="/assets/cover-default.png" alt="Cover Image" class="w-full h-24 object-cover rounded-t-md"        
         - if current_user.administrated_organizations.include?(@event.organization)
@@ -14,7 +14,7 @@ div class="w-[75vw] mx-auto mt-6 p-3 flex justify-between gap-4 mb-24"
                             style="background-color: #{badge_bg_colors[type]}; color: #{badge_text_colors[type]}; border: 1px solid #{badge_text_colors[type]};"
                             class="mx-auto font-['Inter'] px-4 py-2 rounded-full"
                         ] = type
-        h2 class="self-stretch h-7 text-center justify-center text-slate-800 text-lg font-bold font-['Inter'] leading-7"
+        h2 class="self-stretch h-7 text-center justify-center text-slate-800 text-lg font-bold font-['Inter'] leading-7 cursor-pointer" data-action="click->event-logo#redirectToProfile"
             = @event.title + " by " + @event.organization.name
         div class="flex mx-auto justify-center"
             button class="h-12 px-32 py-3 bg-indigo-100 text-[#4338CA] rounded-md flex justify-center items-center gap-2 whitespace-nowrap"
@@ -67,15 +67,15 @@ div class="w-[75vw] mx-auto mt-6 p-3 flex justify-between gap-4 mb-24"
         
         / TODO: Replace with event image if available
         - if @event.image.present?
-            = image_tag url_for(@event.image), class: "w-full object-cover rounded-b-md", data: { target: "logo.output" }
+            = image_tag url_for(@event.image), class: "w-full object-cover rounded-b-md cursor-pointer"
 
 
     div class="w-1/3 flex flex-col gap-4"
         div class="flex flex-col gap-4 rounded-md bg-white"
             div class="w-full flex flex-col gap-2 p-3 justify-center items-center"
                 / TODO: check org logo
-                = image_tag url_for(@organization.logo), class: "h-24 w-24 border border-gray-8 rounded border-2 border-gray-5 object-contain", data: { target: "logo.output" }
-                h2 class="w-72 h-7 text-center justify-center text-black text-lg font-bold font-['Inter'] leading-7"
+                = image_tag url_for(@organization.logo), class: "h-24 w-24 border border-gray-8 rounded border-2 border-gray-5 object-contain cursor-pointer", data: { action: "click->event-logo#redirectToProfile" }
+                h2 class="w-72 h-7 text-center justify-center text-black text-lg font-bold font-['Inter'] leading-7 cursor-pointer" data-action="click->event-logo#redirectToProfile"
                     = @event.organization.name
                 = render CausesList::Component.new( \
                     causes: @event.organization.causes.uniq, \

--- a/app/views/events/explore.html.slim
+++ b/app/views/events/explore.html.slim
@@ -1,8 +1,3 @@
-script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"
-script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"
-script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"
-link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css"
-
 - system_params = ["controller", "action", "format"]
 - num_params = request.params.count { |key, val| key != "query" && val.present? && val != "" && !system_params.include?(key) }
 
@@ -16,7 +11,7 @@ div class="w-full h-64 relative bg-gradient-to-r from-teal-200 via-teal-300/75 t
     img class="w-8 h-8 left-[1244px] top-[165px] absolute" src="/assets/gc-star.png" width="32" height="32"
     img class="w-8 h-8 left-[257px] top-[77px] absolute" src="/assets/gc-star.png" width="32" height="32"
 
-div class="y-12 mx-auto max-w-6xl md:px-28 md:py-20 mt-6"
+div class="y-12 mx-auto max-w-6xl md:px-28 md:py-20 mt-6" data-controller="events" data-events-num-params-value="#{num_params}" data-events-daterange-param-value="#{params[:daterange]}"
     = form_with url: "/events/explore", method: :get, local: true, class: "flex justify-between items-center items-stretch" do |f|
         div.flex.justify-start.items-center.items-stretch.w-3/4
             = f.text_field :query, value: params[:query], class: "text-gray-500 text-sm font-medium font-['Inter'] leading-10 tracking-tight rounded-l-lg flex-grow", placeholder: "Try \"Mental Health Events\""
@@ -24,19 +19,19 @@ div class="y-12 mx-auto max-w-6xl md:px-28 md:py-20 mt-6"
                 svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 17 17" fill="none"
                     path d="M14.875 14.875L10.625 10.625M12.0417 7.08333C12.0417 9.82175 9.82175 12.0417 7.08333 12.0417C4.34492 12.0417 2.125 9.82175 2.125 7.08333C2.125 4.34492 4.34492 2.125 7.08333 2.125C9.82175 2.125 12.0417 4.34492 12.0417 7.08333Z" stroke="#113C7B" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                 p SEARCH
-        button class="text-center text-sky-900 text-base font-semibold font-['Inter'] leading-10 bg-slate-300 rounded-md px-4 flex justify-center items-center gap-2" onclick="showFilters(true)" type="button"
+        button class="text-center text-sky-900 text-base font-semibold font-['Inter'] leading-10 bg-slate-300 rounded-md px-4 flex justify-center items-center gap-2" data-action="click->events#showFilters" data-show="true" type="button"
             svg xmlns="http://www.w3.org/2000/svg" width="13" height="14" viewBox="0 0 13 14" fill="none"
                 path fill-rule="evenodd" clip-rule="evenodd" d="M4.25 0.875V4.375C4.25 4.9 3.9 5.25 3.375 5.25C2.85 5.25 2.5 4.9 2.5 4.375V0.875C2.5 0.35 2.85 0 3.375 0C3.9 0 4.25 0.35 4.25 0.875ZM2.5 12.075C1.5375 11.725 0.75 10.7625 0.75 9.625C0.75 8.1375 1.8875 7 3.375 7C4.8625 7 6 8.1375 6 9.625C6 10.7625 5.3 11.725 4.25 12.075V12.25V13.125C4.25 13.65 3.9 14 3.375 14C2.85 14 2.5 13.65 2.5 13.125V12.25V12.075ZM9.5 9.625V13.125C9.5 13.65 9.85 14 10.375 14C10.9 14 11.25 13.65 11.25 13.125V9.625C11.25 9.1 10.9 8.75 10.375 8.75C9.85 8.75 9.5 9.1 9.5 9.625ZM10.375 7C8.8875 7 7.75 5.8625 7.75 4.375C7.75 3.2375 8.5375 2.275 9.5 1.925V1.75V0.875C9.5 0.35 9.85 0 10.375 0C10.9 0 11.25 0.35 11.25 0.875V1.75V1.925C12.2125 2.275 13 3.2375 13 4.375C13 5.8625 11.8625 7 10.375 7Z" fill="#113C7B"
             p FILTERS 
             - if num_params > 0
-                p class=" text-sky-900 font-['Inter'] leadning-normal" 
+                p class="text-sky-900 font-['Inter'] leading-normal" 
                     | (#{num_params}) 
 
-        div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-1/3 p-6 bg-white rounded-lg z-10 shadow-lg right-0 hidden" id="filters"
+        div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-1/3 p-6 bg-white rounded-lg z-10 shadow-lg right-0 hidden" data-events-target="filters" id="filters"
             div class="flex justify-between items-center mb-4"
                 h2 class="text-xl font-semibold font-['Inter'] text-gray-900"
                     | Filters
-                button type="button" class="text-gray-500 hover:text-gray-800" onclick="showFilters(false)"
+                button type="button" class="text-gray-500 hover:text-gray-800" data-action="click->events#showFilters" data-show="false"
                     | ✕
             
             div class="flex flex-col gap-6"
@@ -77,11 +72,11 @@ div class="y-12 mx-auto max-w-6xl md:px-28 md:py-20 mt-6"
                 div
                     h3 class="text-gray-900 text-base font-semibold font-['Inter'] mb-2"
                         | Date Range
-                    = f.text_field :daterange, value: params[:daterange], class: "w-full rounded-md text-center", placeholder: "Select date range"
+                    = f.text_field :daterange, value: params[:daterange], class: "w-full rounded-md text-center", placeholder: "Select date range", data: { events_target: "daterange" }
                 
                 - if num_params > 0
                     div class="mt-6 flex justify-between"
-                        button type="button" class="px-4 py-2 bg-gray-200 text-gray-900 font-semibold rounded-md" onclick="window.location.href = '/events/explore'"
+                        button type="button" class="px-4 py-2 bg-gray-200 text-gray-900 font-semibold rounded-md" data-action="click->events#clearFilters"
                             | Clear Filters
                         button type="submit" class="px-4 py-2 bg-[#9AE2E0] text-sky-900 font-semibold rounded-md"
                             | Apply Filters
@@ -94,16 +89,16 @@ div class="y-12 mx-auto max-w-6xl md:px-28 md:py-20 mt-6"
         h2 class="text-center justify-center text-black text-2xl font-normal font-['Inter'] leading-9"
             | Upcoming Events
         div.inline-flex.rounded-md.shadow-xs role="group"
-            button.px-4.py-2.text-sm.font-medium.text-gray-700.bg-gray-200.border.border-gray-300.rounded-l-md.flex.justify-center.items-center.gap-2 onclick="toggleList(true);" id="events_list_button"
+            button.px-4.py-2.text-sm.font-medium.text-gray-700.bg-gray-200.border.border-gray-300.rounded-l-md.flex.justify-center.items-center.gap-2 data-action="click->events#toggleList" data-type="list" data-events-target="listButton" id="events_list_button"
                 svg xmlns="http://www.w3.org/2000/svg" width="15" height="11" viewBox="0 0 15 11" fill="none"
                     path d="M1 0.75H13.6667M1 5.5H13.6667M1 10.25H13.6667" stroke="black" stroke-linecap="round" stroke-linejoin="round"
                 p List 
-            button.px-4.py-2.text-sm.font-medium.text-gray-700.bg-gray-100.border.border-gray-300.rounded-r-md.flex.justify-center.items-center.gap-2 onclick="toggleList(false);" id="events_calendar_button"
+            button.px-4.py-2.text-sm.font-medium.text-gray-700.bg-gray-100.border.border-gray-300.rounded-r-md.flex.justify-center.items-center.gap-2 data-action="click->events#toggleList" data-type="calendar" data-events-target="calendarButton" id="events_calendar_button"
                 svg xmlns="http://www.w3.org/2000/svg" width="18" height="17" viewBox="0 0 18 17" fill="none"
                     path d="M5.44444 4.05556V0.5M12.5556 4.05556V0.5M4.55556 7.61111H13.4444M2.77778 16.5H15.2222C16.2041 16.5 17 15.7041 17 14.7222V4.05556C17 3.07372 16.2041 2.27778 15.2222 2.27778H2.77778C1.79594 2.27778 1 3.07372 1 4.05556V14.7222C1 15.7041 1.79594 16.5 2.77778 16.5Z" stroke="black" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round"
                 p Calendar
 
-    div id="events_list" class="h-full bg-white mt-3 rounded-md"
+    div id="events_list" class="h-full bg-white mt-3 rounded-md" data-events-target="list"
         - if @events.present?
             ul class="flex flex-col divide-y divide-gray-8 "
             - @events.each do |event|
@@ -113,117 +108,8 @@ div class="y-12 mx-auto max-w-6xl md:px-28 md:py-20 mt-6"
             p class="text-center text-grey-2 pt-10 h-full"
                 | No events found for your search.
 
-    div id="events_calendar" class="hidden h-0 w-0" style="min-height: 100vh;"
+    div id="events_calendar" class="hidden h-0 w-0" style="min-height: 100vh;" data-events-target="calendar"
         = render Calendar::Component.new(admin: false)
 
-
-javascript: 
-  function toggleList(isList) {
-    const listEl = document.getElementById('events_list');
-    const calendarEl = document.getElementById('events_calendar');
-    const listBtn = document.getElementById('events_list_button');
-    const calendarBtn = document.getElementById('events_calendar_button');
-
-    if (isList) {
-      // Show list and hide calendar
-      listEl.classList.remove('hidden');
-      calendarEl.classList.add('hidden');
-      calendarEl.classList.add('h-0');
-      calendarEl.classList.add('w-0');
-      
-      // Change button styles
-      listBtn.classList.add('bg-gray-200');
-      calendarBtn.classList.remove('bg-gray-200');
-    } else {
-      // Hide list
-      listEl.classList.add('hidden');
-      
-      // Show calendar container with proper dimensions 
-      calendarEl.classList.remove('hidden');
-      calendarEl.classList.remove('h-0');
-      calendarEl.classList.remove('w-0');
-      
-      // Change button styles
-      listBtn.classList.remove('bg-gray-200');
-      calendarBtn.classList.add('bg-gray-200');
-
-      window.calendar.render();
-    }
-  }
-
-  // Add the showFilters function to toggle filter visibility
-  function showFilters(show) {
-    const filtersEl = document.getElementById('filters');
-    if (show) {
-      filtersEl.classList.remove('hidden');
-    } else {
-      filtersEl.classList.add('hidden');
-    }
-  }
-
-  function parseDateRange(dateRangeStr) {
-    if (!dateRangeStr) return { start: null, end: null };
-    
-    // Decode URL-encoded characters
-    const decodedStr = decodeURIComponent(dateRangeStr);
-    
-    // Split by the hyphen to get start and end parts
-    const parts = decodedStr.split(' - ');
-    if (parts.length !== 2) return { start: null, end: null };
-    
-    const startStr = parts[0];
-    const endStr = parts[1];
-    
-    // Parse dates directly with moment
-    const startDate = moment(startStr, 'M/D hh:mm A');
-    const endDate = moment(endStr, 'M/D hh:mm A');
-    
-    return {
-      start: startDate.isValid() ? startDate : null,
-      end: endDate.isValid() ? endDate : null
-    };
-  }
-
-  $(function() {
-    // Get the daterange parameter from URL
-    const urlParams = new URLSearchParams(window.location.search);
-    const dateRangeParam = urlParams.get('daterange');
-    
-    // Initialize daterangepicker with appropriate options
-    const daterangepickerOptions = {
-      timePicker: true,
-      autoUpdateInput: false, // Don't update input until user selects a date range
-      locale: {
-        format: 'M/D h:mm A',
-        cancelLabel: 'Clear',
-        applyLabel: 'Apply'
-      },
-      drops: 'up',
-      opens: 'center'
-    };
-    
-    // Only set startDate and endDate if there's a valid daterange parameter
-    if (dateRangeParam) {
-      const parsedDates = parseDateRange(dateRangeParam);
-      if (parsedDates.start && parsedDates.end) {
-        daterangepickerOptions.startDate = parsedDates.start;
-        daterangepickerOptions.endDate = parsedDates.end;
-        daterangepickerOptions.autoUpdateInput = true; // Update input with the existing date range
-      }
-    }
-    
-    // Initialize daterangepicker
-    const dateRangePicker = $('input[name="daterange"]').daterangepicker(daterangepickerOptions);
-    
-    // Add event listeners to update the input value when user selects a date range
-    dateRangePicker.on('apply.daterangepicker', function(ev, picker) {
-      $(this).val(picker.startDate.format('M/D h:mm A') + ' - ' + picker.endDate.format('M/D h:mm A'));
-    });
-    
-    // Clear the input when user cancels
-    dateRangePicker.on('cancel.daterangepicker', function(ev, picker) {
-      $(this).val('');
-    });
-  });
 
 


### PR DESCRIPTION
### Context
Nothing would happen if you clicked on the logo or name of the nonprofit hosting a event in the events tab.

### What changed
Removed JavaScript code from view/events/explore.html.slim and placed into events_controller.js.
Created event_logo_controller.js to redirect users to the nonprofit's profile page if they clicked their name or logo in the events tab.

### How to test it
Go to Events
Click on a event
Click on the nonprofit's logo in the top right
Observe being redirected to the nonprofit's profile
Return to the event tab
Click on the nonprofit's name in either the event title or underneatht the nonprofit's logo
Observe being redirected to the nonprofit's profile

### References
Row 10
[Bug Sheet](https://docs.google.com/spreadsheets/d/158klFxrZFr_UkGeR5DnvHWpxj3JB-oIDO8Z57gvgHaA/edit?gid=0#gid=0)
