### PR TITLE
Event Hover Effect

### DIFF
--- a/app/components/event_list_card/component.html.erb
+++ b/app/components/event_list_card/component.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-col align-items-start gap-3 self-stretch py-5 px-3 border-b-2 border-[#E6E6E6]">
+<div class="flex flex-col align-items-start gap-3 self-stretch py-5 px-3 border-b-2 border-[#E6E6E6] hover:shadow-lg hover:bg-gray-50 transition duration-200 ease-in-out" onclick="window.location.href='/events/explore/<%= event.id %>'" style="cursor: pointer;">
   <div class="flex justify-between items-center gap-10 self-stretch">
     <div class="flex-none">
       <% adjusted_start = event.start_time.in_time_zone(helpers.get_timezone()) %>
@@ -17,7 +17,7 @@
       <% end %>
       
       <div class="flex flex-col gap-0">
-        <h2 class="text-black text-base font-bold leading-normal font-['Inter'] hover:underline"><a href="/events/explore/<%= event.id %>"><%= event.title %></a></h2>
+        <h2 class="text-black text-base font-bold leading-normal font-['Inter'] hover:underline"><%= event.title %></h2>
 
         <% if event.organization && !@small %>
             <div class="text-xs font-medium leading-tight font-['Inter']"><%= event.organization.name %></div>


### PR DESCRIPTION
### Context
A user could only navigate to the event profile if they clicked on the event title in the Events tab. This is frustrating because users expect to be able to click on the entirety of the event card to be able to navigate to the event. There was also no visual indication where you could click.

### What changed
Contained the event's path in the outermost div, allowing users to click anywhere on the event card to navigate to the event page. 
Added Tailwind CSS classes to provide visual indication that the user can click on the event card when they hovered over the component. Added a shadow and changed the background of the card to be a darker gray.   

### How to test it
Go to Events tab
Hover over an event and observe the background turn a darker gray and the card obtaining a shadow
Click on any white space (or anywhere) on the event card component 
Observe being directed to that specific event's page

### References
Row 17
[Bug Sheet](https://docs.google.com/spreadsheets/d/158klFxrZFr_UkGeR5DnvHWpxj3JB-oIDO8Z57gvgHaA/edit?gid=0#gid=0)
