### PR TITLE
Scrolling opening hours

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -23,12 +23,22 @@ class OrganizationsController < ApplicationController
     authorize @organization
     if @organization.update(organization_params)
       update_tags(@organization, JSON.parse(params["organization"]["tags_attributes"])) unless params["organization"]["tags_attributes"].strip.empty?
-      redirect_to my_account_path
-      flash[:notice] = "The Organization was successfully updated"
+
+      # Handle AJAX requests differently
+      if request.xhr?
+        render json: {success: true, message: "The Organization was successfully updated"}
+      else
+        redirect_to my_account_path
+        flash[:notice] = "The Organization was successfully updated"
+      end
     else
       set_form_data
-      flash.now[:alert] = "The Organization was not updated"
-      render "edit", status: :unprocessable_entity
+      if request.xhr?
+        render json: {success: false, errors: @organization.errors.full_messages}, status: :unprocessable_entity
+      else
+        flash.now[:alert] = "The Organization was not updated"
+        render "edit", status: :unprocessable_entity
+      end
     end
   end
 

--- a/app/javascript/controllers/detect_form_changes_controller.js
+++ b/app/javascript/controllers/detect_form_changes_controller.js
@@ -15,6 +15,11 @@ export default class extends Controller {
   captureUserInput(event) {
     const input = event.target;
 
+    // Ignore changes in modal fields
+    if (this.isInModal(input)) {
+      return;
+    }
+
     if (this.utilityInputTargets.includes(input) || this.eventAndInputIncompatible(event, input)) {
       return;
     }
@@ -31,7 +36,7 @@ export default class extends Controller {
     const currentFormInputs = [...form.querySelectorAll(this.inputTypesValue)];
 
     return (this.validInputsLength(currentFormInputs) !== form.initialNumberOfInputs) ||
-      currentFormInputs.some(input => this.inputValueChanged(input));
+      currentFormInputs.some(input => this.inputValueChanged(input) && !this.isInModal(input));
   }
 
   inputValueChanged(input) {
@@ -63,6 +68,12 @@ export default class extends Controller {
 
     return (event.type === "input" && inputIsSelectable) ||
       (event.type === "change" && !inputIsSelectable);
+  }
+
+  isInModal(input) {
+    // Check if the input is inside a modal
+    const modalContainer = input.closest('[data-modal-target="container"]');
+    return modalContainer !== null;
   }
 
   // users can add or remove inputs


### PR DESCRIPTION
### Context
Users were experiencing a UX/UI bug when editing opening hours in the organization edit form. When a user would edit the "Hours of Operation" in a popup and click "Submit", the entire page would refresh and scroll back to the top, instead of just closing the modal and maintaining the user's position on the page.

### What changed

- Fixed scroll position capture in modal_controller.js to save position before modal opens
- Implemented AJAX submission for the opening hours modal to prevent page refresh
- Added JSON response handling in organizations_controller.rb for AJAX requests
- Updated detect_form_changes_controller.js to ignore modal input changes

### How to test it
Go to organization edit page and scroll down
Open "Edit Opening Hours" modal
Make changes and click "Submit"
Modal should close without page refresh, maintaining scroll position

### References

ClickUp ticket: https://app.clickup.com/t/86b13nr00
