### PR TITLE
Stabilize test environment and system spec runtime defaults

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,7 +2,7 @@
 
 class ApplicationMailer < ActionMailer::Base
   before_action :attach_logos
-  default from: Rails.application.credentials.dig(:mailer, :from)
+  default from: Rails.application.credentials.dig(:mailer, :from) || "no-reply@givingconnection.test"
   layout "mailer"
 
   private

--- a/app/mailers/newsletter_mailer.rb
+++ b/app/mailers/newsletter_mailer.rb
@@ -1,6 +1,4 @@
 class NewsletterMailer < ApplicationMailer
-  default from: Rails.application.credentials.dig(:mailer, :from)
-
   def verification_email(newsletter)
     @newsletter = newsletter
     @verification_url = verify_newsletter_subscription_url(token: newsletter.verification_token)

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -26,7 +26,9 @@ By default, it renders:
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
     <%= stylesheet_link_tag "application.tailwind" %>
     <%= javascript_include_tag *webpack_asset_urls('administrate', 'js'), defer: true %>
-    <%= javascript_include_tag 'https://maps.googleapis.com/maps/api/js?key='+Rails.application.credentials.dig(:google_api_key)+'&loading=async&libraries=places&callback=initMap', 'data-turbolinks-eval': 'false', defer: true %>
+    <% if (google_api_key = Rails.application.credentials.dig(:google_api_key).presence) %>
+      <%= javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{google_api_key}&loading=async&libraries=places&callback=initMap", "data-turbolinks-eval": "false", defer: true %>
+    <% end %>
   </head>
   <body>
     <%= render "icons" %>

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,5 +1,5 @@
 Recaptcha.configure do |config|
-  config.site_key = Rails.application.credentials.dig(:recaptcha, :RECAPTCHA_SITE_KEY)
-  config.secret_key = Rails.application.credentials.dig(:recaptcha, :RECAPTCHA_SECRET_KEY)
-  config.skip_verify_env = ["development"]
+  config.site_key = Rails.application.credentials.dig(:recaptcha, :RECAPTCHA_SITE_KEY) || "test-site-key"
+  config.secret_key = Rails.application.credentials.dig(:recaptcha, :RECAPTCHA_SECRET_KEY) || "test-secret-key"
+  config.skip_verify_env = %w[development test]
 end

--- a/spec/services/spreadsheet_import/address_location_parser_spec.rb
+++ b/spec/services/spreadsheet_import/address_location_parser_spec.rb
@@ -2,12 +2,20 @@ require "rails_helper"
 
 RSpec.describe SpreadsheetImport::AddressLocationParser do
   it "returns the correct coordinates for an example place" do
+    allow(Geocoder).to receive(:search).with("5800 MARMION WAY, LOS ANGELES, CA, 90042").and_return([
+      Struct.new(:latitude, :longitude).new(34.1110080, -118.1923320)
+    ])
+
     result = described_class.new("5800 MARMION WAY, LOS ANGELES, CA, 90042").call
     expect(result.latitude).to be_within(0.001).of(34.1110080)
     expect(result.longitude).to be_within(0.001).of(-118.1923320)
   end
 
   it "returns the correct coordinates for an example place" do
+    allow(Geocoder).to receive(:search).with("2133 N HICKS AVE	LOS ANGELES	CA	90032-3643").and_return([
+      Struct.new(:latitude, :longitude).new(34.0682933, -118.1909603)
+    ])
+
     result = described_class.new("2133 N HICKS AVE	LOS ANGELES	CA	90032-3643").call
     expect(result.latitude).to be_within(0.001).of(34.0682933)
     expect(result.longitude).to be_within(0.001).of(-118.1909603)

--- a/spec/system/support/cuprite_setup.rb
+++ b/spec/system/support/cuprite_setup.rb
@@ -6,15 +6,26 @@ require "capybara/cuprite"
 # NOTE: The name :cuprite is already registered by Rails.
 # See https://github.com/rubycdp/cuprite/issues/180
 Capybara.register_driver(:better_cuprite) do |app|
+  browser_path = ENV["BROWSER_PATH"].presence || [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/opt/homebrew/bin/chromium",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium"
+  ].find { |path| File.exist?(path) }
+
   Capybara::Cuprite::Driver.new(
     app,
     window_size: [1200, 800],
+    browser_path: browser_path,
     # See additional options for Dockerized environment in the respective section of this article
-    browser_options: {},
+    browser_options: {
+      "no-sandbox" => nil,
+      "disable-gpu" => nil,
+      "disable-dev-shm-usage" => nil
+    },
     # Increase Chrome startup wait time (required for stable CI builds)
-    process_timeout: 15,
-    # Enable debugging capabilities
-    inspector: true,
+    process_timeout: 45,
+    # Disable inspector for stability in automated runs
+    inspector: false,
     # Allow running Chrome in a headful mode by setting HEADLESS env
     # var to a falsey value
     headless: !ENV["HEADLESS"].in?(%w[n 0 no false])


### PR DESCRIPTION
### Context
Some local and CI test runs were failing due to missing environment credentials and browser/runtime assumptions, which made system specs and mailer-dependent specs brittle outside fully provisioned environments.

### What Changed
- Added safe mailer sender fallback in `app/mailers/application_mailer.rb` and removed duplicate `from` config in `app/mailers/newsletter_mailer.rb`.
- Guarded Google Maps include in `app/views/layouts/admin/application.html.erb` so admin pages do not crash when `google_api_key` is absent.
- Updated `config/initializers/recaptcha.rb` with test-safe fallback keys and included `test` in `skip_verify_env`.
- Made geocoder parser spec deterministic by stubbing geocoding responses in `spec/services/spreadsheet_import/address_location_parser_spec.rb`.
- Hardened Cuprite setup in `spec/system/support/cuprite_setup.rb` with explicit browser path discovery, stable browser flags, disabled inspector, and higher process timeout.

### How to Test
1. Run `mise exec ruby@3.2.8 node@20.17.0 -- bundle exec rspec`.
2. Confirm system specs no longer fail due to missing browser binary or startup timeout.
3. Confirm specs that create users/mailers no longer fail due to missing SMTP `from` credentials.
4. Confirm recaptcha-rendering pages in test mode do not raise missing site key errors.

### Deployment Tasks
None.