### PR TITLE
Enable TLS + hostname for staging proxy

### DIFF
--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -22,8 +22,8 @@ servers:
       memory: 256m
 
 proxy:
-  ssl: false
-  host: 138.197.90.4
+  ssl: true
+  host: staging.givingconnection.org
   app_port: 3000
   healthcheck:
     interval: 3


### PR DESCRIPTION
## Context
Staging environment is being exposed at `staging.givingconnection.org` (Cloudflare DNS-only → DigitalOcean droplet `138.197.90.4`).

The current `config/deploy.staging.yml` proxy is configured for the droplet IP with `ssl: false`. Since kamal-proxy routes by `Host` header, requests for `staging.givingconnection.org` are dropped, and HTTPS isn't served at all.

This also unblocks P2 follow-up #1 from PR #754: "Staging has no TLS."

## What Changed
- `config/deploy.staging.yml`: set `proxy.ssl: true` and `proxy.host: staging.givingconnection.org` so kamal-proxy accepts the subdomain and issues a Let's Encrypt cert on first request.

## How to Test
- [ ] Cloudflare DNS A record `staging` → `138.197.90.4` exists (DNS-only / gray cloud)
- [ ] Droplet firewall allows inbound 80 + 443
- [ ] `kamal deploy -d staging` succeeds
- [ ] `kamal proxy logs -d staging --follow` shows Let's Encrypt cert issuance
- [ ] `curl -I https://staging.givingconnection.org/up` returns 200 with a valid cert

## Deployment Tasks
- Cloudflare DNS record must be in place before deploy (so Let's Encrypt HTTP-01 challenge can resolve).
- After the cert issues, Cloudflare proxy (orange cloud) can be enabled with SSL mode "Full (strict)" if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)