### PR TITLE
Add .worktree-symlinks for cw bootable worktrees

### DIFF
--- a/.worktree-symlinks
+++ b/.worktree-symlinks
@@ -1,0 +1,20 @@
+# Symlinked by `cw` into new worktrees so they boot without re-running setup
+# (bundle install, yarn install, credentials setup). Paths are relative to
+# the repo root and must already exist there.
+
+# App config / secrets (gitignored, required to boot Rails)
+.env
+config/master.key
+
+# Kamal deploy secrets (gitignored)
+.kamal/secrets-common
+.kamal/secrets.production
+.kamal/secrets.staging
+
+# Bundler local config
+.bundle
+
+# JS dependencies (169M; shared to skip a fresh yarn install per worktree).
+# Note: running `yarn install` in one worktree updates node_modules for all
+# worktrees since it's the same symlinked directory.
+node_modules


### PR DESCRIPTION
## Context
We create parallel feature worktrees for this repo (see ../worktrees/), but each one previously needed its own manual copy of gitignored setup files before it could boot: the environment config file, the Rails credentials key, Kamal deploy config, bundler config, and a full yarn install for node_modules. That's slow and duplicates about 170MB of dependencies per worktree.

## What Changed
- Added .worktree-symlinks, a file read by the cw worktree helper. Each line is a gitignored, repo-root-relative path that cw symlinks (not copies) from the main checkout into any new worktree it creates.
- Included paths: the environment config file, the Rails credentials key, the Kamal per-environment deploy config files, the bundler config directory, and node_modules.

## How to Test
- Run cw some-branch-name from the repo root and confirm the new worktree has working symlinks for all entries listed in .worktree-symlinks.
- Confirm the app boots in the new worktree without running bundle install or yarn install first.
- Edge case: since node_modules and the bundler config are symlinked rather than copied, running yarn install or bundle install in one worktree updates the shared directory for all worktrees using it. This is called out in a comment in the file.

## Deployment Tasks
None.
