### PR TITLE
Update project gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 3.26"
   gem "cuprite"
-  # Easy installation and use of web drivers to run system tests with browsers
+  gem "selenium-webdriver", ">= 4.14"
   gem "rails-controller-testing"
   gem "rspec-sidekiq"
   gem "rspec-retry"
@@ -130,7 +130,6 @@ group :test do
   gem "simplecov", require: false
   gem "test-prof", "~> 1.0"
   gem "timecop"
-  gem "webdrivers", "~> 5.2", require: false
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,7 +325,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    loofah (2.24.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lumberjack (1.2.10)
@@ -435,8 +435,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.2)
-      loofah (~> 2.21)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (7.2.3.1)
       actionpack (= 7.2.3.1)
@@ -552,9 +552,11 @@ GEM
       parser
     securerandom (0.4.1)
     selectize-rails (0.12.6)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.46.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
+      rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     shellany (0.0.1)
     shoulda-matchers (4.5.1)
@@ -636,10 +638,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webrick (1.9.1)
     websocket (1.2.11)
     websocket-driver (0.8.2)
@@ -728,6 +726,7 @@ DEPENDENCIES
   rubocop-rails (~> 2)!
   rubocop-rspec (~> 2)!
   scout_apm
+  selenium-webdriver (>= 4.14)
   shoulda-matchers (~> 4.0)
   sidekiq (< 7)
   simplecov
@@ -746,7 +745,6 @@ DEPENDENCIES
   uri (>= 1.0.4)
   view_component (~> 3.25)
   web-console (>= 4.1.0)
-  webdrivers (~> 5.2)
 
 RUBY VERSION
    ruby 3.4.8p72


### PR DESCRIPTION
### Context
- Some projects gems were outdated and causing the security ci to fail

### What changed
- updated the gems to fit the requirements

### How to test it

### References

[ClickUp ticket](url)
